### PR TITLE
diag: bypass staleness + verbose INFO logging for week-long debug run

### DIFF
--- a/custom_components/carelink/__init__.py
+++ b/custom_components/carelink/__init__.py
@@ -22,6 +22,7 @@ from homeassistant.helpers.update_coordinator import (
 from .api import CarelinkClient, LEGACY_AUTH_FILE, AUTH_FILE_PREFIX, SHARED_AUTH_FILE
 from .tandem_api import TandemSourceClient, TandemAuthError, TandemApiError, parse_dotnet_date
 from .nightscout_uploader import NightscoutUploader
+from .helpers import is_data_stale
 
 from .const import (
     CLIENT,
@@ -793,15 +794,16 @@ class TandemCoordinator(DataUpdateCoordinator):
             metadata_entry = None
 
         if max_date_str and self._last_max_date and max_date_str == self._last_max_date and self.data:
-            _LOGGER.debug(
-                "TandemCoordinator: maxDateWithEvents unchanged (%s), returning cached data (no new pump events)",
+            _LOGGER.info(
+                "[Tandem] Poll: no new pump data (maxDate=%s, serving %d cached keys)",
                 max_date_str,
+                len(self.data),
             )
             return self.data
 
-        _LOGGER.debug(
-            "TandemCoordinator: maxDateWithEvents changed (%s -> %s), fetching pump events",
-            self._last_max_date,
+        _LOGGER.info(
+            "[Tandem] New pump data: maxDate %s → %s — fetching events",
+            self._last_max_date or "(first poll)",
             max_date_str,
         )
 
@@ -825,14 +827,13 @@ class TandemCoordinator(DataUpdateCoordinator):
         _LOGGER.debug("Tandem before data parsing: %s", sanitize_for_logging(recent_data))
 
         # Log what data sources are available
-        _LOGGER.debug(
-            "Tandem data sources: pump_metadata=%s, pumper_info=%s, "
-            "pump_events=%s, therapy_timeline=%s, dashboard_summary=%s",
-            "present" if recent_data.get("pump_metadata") else "MISSING",
-            "present" if recent_data.get("pumper_info") else "MISSING",
-            "present" if recent_data.get("pump_events") else "MISSING",
-            "present" if recent_data.get("therapy_timeline") else "MISSING",
-            "present" if recent_data.get("dashboard_summary") else "MISSING",
+        _LOGGER.info(
+            "[Tandem] Fetch OK — metadata=%s  pumper=%s  pump_events=%s  therapy=%s  dashboard=%s",
+            "OK" if recent_data.get("pump_metadata") else "MISSING",
+            "OK" if recent_data.get("pumper_info") else "MISSING",
+            "OK" if recent_data.get("pump_events") else "MISSING",
+            "OK" if recent_data.get("therapy_timeline") else "MISSING",
+            "OK" if recent_data.get("dashboard_summary") else "MISSING",
         )
 
         # ── Device info from pump metadata ───────────────────────────────
@@ -929,7 +930,25 @@ class TandemCoordinator(DataUpdateCoordinator):
             except Exception as e:
                 _LOGGER.error("TandemCoordinator: Error parsing dashboard summary: %s", e, exc_info=True)
 
-        _LOGGER.debug("Tandem _async_update_data: %d keys", len(data))
+        # Diagnostic: show CGM reading, its age, and whether staleness would have fired
+        cgm_mgdl = data.get("tandem_last_sg_mgdl")
+        cgm_ts = data.get("tandem_last_sg_timestamp")
+        try:
+            if cgm_ts and hasattr(cgm_ts, "astimezone"):
+                age_secs = (datetime.now(timezone.utc) - cgm_ts.astimezone(timezone.utc)).total_seconds()
+                age_str = f"{int(age_secs / 60)}min"
+            else:
+                age_str = "N/A"
+        except Exception:
+            age_str = "?"
+        _LOGGER.info(
+            "[Tandem] Parse done: %d keys | CGM=%s mg/dL @ %s (age=%s) | stale_check=%s",
+            len(data),
+            cgm_mgdl if cgm_mgdl is not None else "N/A",
+            cgm_ts.strftime("%H:%M:%S %Z") if cgm_ts and hasattr(cgm_ts, "strftime") else "N/A",
+            age_str,
+            is_data_stale(data),
+        )
 
         # ── Import long-term statistics with correct timestamps ──────────
         if pump_events:
@@ -1995,7 +2014,7 @@ class TandemCoordinator(DataUpdateCoordinator):
                     unit_of_measurement="mmol/L",
                 )
                 async_import_statistics(self.hass, cgm_meta, cgm_stats)
-                _LOGGER.debug("Tandem: Imported %d CGM statistics", len(cgm_stats))
+                _LOGGER.info("[Tandem] Imported %d CGM statistics", len(cgm_stats))
             except Exception as e:
                 _LOGGER.warning("Tandem: Failed to import CGM statistics: %s", e)
 
@@ -2010,7 +2029,7 @@ class TandemCoordinator(DataUpdateCoordinator):
                     unit_of_measurement="units",
                 )
                 async_import_statistics(self.hass, iob_meta, iob_stats)
-                _LOGGER.debug("Tandem: Imported %d IOB statistics", len(iob_stats))
+                _LOGGER.info("[Tandem] Imported %d IOB statistics", len(iob_stats))
             except Exception as e:
                 _LOGGER.warning("Tandem: Failed to import IOB statistics: %s", e)
 
@@ -2025,7 +2044,7 @@ class TandemCoordinator(DataUpdateCoordinator):
                     unit_of_measurement="U/hr",
                 )
                 async_import_statistics(self.hass, basal_meta, basal_stats)
-                _LOGGER.debug("Tandem: Imported %d basal statistics", len(basal_stats))
+                _LOGGER.info("[Tandem] Imported %d basal statistics", len(basal_stats))
             except Exception as e:
                 _LOGGER.warning("Tandem: Failed to import basal statistics: %s", e)
 

--- a/custom_components/carelink/sensor.py
+++ b/custom_components/carelink/sensor.py
@@ -27,12 +27,10 @@ from .const import (
     DOMAIN,
     SENSORS,
     TANDEM_SENSORS,
-    TANDEM_SENSORS_ALWAYS_AVAILABLE,
     PLATFORM_TYPE,
     PLATFORM_CARELINK,
     PLATFORM_TANDEM,
 )
-from .helpers import is_data_stale
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -76,16 +74,14 @@ class CarelinkSensorEntity(CoordinatorEntity, SensorEntity):
 
     @property
     def available(self) -> bool:
-        """Return True if the sensor has valid, non-stale data."""
-        if not super().available:
-            return False
-        # Only apply staleness check to Tandem sensors
-        if self._platform_type != PLATFORM_TANDEM:
-            return True
-        # Timestamp/diagnostic sensors stay available even when data is stale
-        if self.sensor_description.key in TANDEM_SENSORS_ALWAYS_AVAILABLE:
-            return True
-        return not is_data_stale(self.coordinator.data)
+        """Return True if the coordinator is available.
+
+        DIAGNOSTIC MODE: staleness check bypassed so sensors always show their
+        last known value instead of becoming unavailable.  The coordinator logs
+        [Tandem] stale_check=True/False on every update so staleness is still
+        visible in the HA log without hiding data from the UI.
+        """
+        return super().available
 
     @property
     def name(self) -> str:

--- a/tests/test_tandem_stale_data.py
+++ b/tests/test_tandem_stale_data.py
@@ -144,45 +144,44 @@ class TestSensorAvailability:
         )
         return entity
 
-    @patch("custom_components.carelink.sensor.is_data_stale", return_value=True)
-    def test_tandem_glucose_unavailable_when_stale(self, mock_stale):
-        """Tandem glucose sensor should be unavailable when data is stale."""
-        entity = self._make_sensor(TANDEM_SENSOR_KEY_LASTSG_MMOL)
-        assert entity.available is False
+    # DIAGNOSTIC MODE: staleness check is bypassed in sensor.available so that
+    # sensors always show their last known value.  Stale detection still runs
+    # inside the coordinator and is reported in the HA log as stale_check=True.
+    # These tests document the diagnostic-mode expectation; revert when the
+    # staleness check is re-enabled in sensor.py.
 
-    @patch("custom_components.carelink.sensor.is_data_stale", return_value=False)
-    def test_tandem_glucose_available_when_fresh(self, mock_stale):
-        """Tandem glucose sensor should be available when data is fresh."""
+    def test_tandem_glucose_shows_last_value_when_stale(self):
+        """DIAG: glucose sensor stays available (shows last value) even when stale."""
         entity = self._make_sensor(TANDEM_SENSOR_KEY_LASTSG_MMOL)
         assert entity.available is True
 
-    @patch("custom_components.carelink.sensor.is_data_stale", return_value=True)
-    def test_tandem_basal_unavailable_when_stale(self, mock_stale):
-        """Tandem basal rate sensor should be unavailable when data is stale."""
+    def test_tandem_glucose_available_when_fresh(self):
+        """Tandem glucose sensor is available when coordinator is healthy."""
+        entity = self._make_sensor(TANDEM_SENSOR_KEY_LASTSG_MMOL)
+        assert entity.available is True
+
+    def test_tandem_basal_shows_last_value_when_stale(self):
+        """DIAG: basal rate sensor stays available (shows last value) even when stale."""
         entity = self._make_sensor(TANDEM_SENSOR_KEY_BASAL_RATE)
-        assert entity.available is False
+        assert entity.available is True
 
-    @patch("custom_components.carelink.sensor.is_data_stale", return_value=True)
-    def test_tandem_iob_unavailable_when_stale(self, mock_stale):
-        """Tandem active insulin sensor should be unavailable when data is stale."""
+    def test_tandem_iob_shows_last_value_when_stale(self):
+        """DIAG: IOB sensor stays available (shows last value) even when stale."""
         entity = self._make_sensor(TANDEM_SENSOR_KEY_ACTIVE_INSULIN)
-        assert entity.available is False
+        assert entity.available is True
 
-    @patch("custom_components.carelink.sensor.is_data_stale", return_value=True)
-    def test_always_available_sensors_stay_available(self, mock_stale):
-        """Timestamp/diagnostic sensors should stay available even when stale."""
+    def test_always_available_sensors_stay_available(self):
+        """Timestamp/diagnostic sensors should stay available (via coordinator health)."""
         for sensor_key in TANDEM_SENSORS_ALWAYS_AVAILABLE:
             entity = self._make_sensor(sensor_key)
-            assert entity.available is True, f"Sensor {sensor_key} should remain available when data is stale"
+            assert entity.available is True, f"Sensor {sensor_key} should remain available"
 
-    @patch("custom_components.carelink.sensor.is_data_stale", return_value=True)
-    def test_carelink_sensors_unaffected_by_staleness(self, mock_stale):
-        """Carelink (Medtronic) sensors should not be affected by staleness check."""
+    def test_carelink_sensors_unaffected_by_staleness(self):
+        """Carelink (Medtronic) sensors should always be available."""
         entity = self._make_sensor(
             TANDEM_SENSOR_KEY_LASTSG_MMOL,
             platform_type=PLATFORM_CARELINK,
         )
-        # Carelink sensors should always be available (staleness doesn't apply)
         assert entity.available is True
 
     def test_unavailable_when_coordinator_not_connected(self):


### PR DESCRIPTION
## Summary
- **Staleness unavailability bypassed** — sensors always show their last known value instead of going "unavailable". The stale check still runs in the coordinator and is reported in the HA log as `stale_check=True/False`, so you can see the staleness state without losing data from the UI.
- **INFO-level logging added** to make data exchange visible without enabling debug mode:
  - Every poll: `[Tandem] Poll: no new pump data (maxDate=…, N cached keys)` — confirms the loop is running
  - On new data: `[Tandem] New pump data: maxDate … → …` — confirms pump upload was detected
  - After fetch: `[Tandem] Fetch OK — metadata=OK pump_events=OK therapy=MISSING dashboard=MISSING`
  - After parse: `[Tandem] Parse done: 61 keys | CGM=142 mg/dL @ 14:35:22 UTC (age=4min) | stale_check=False`
  - Stats: `[Tandem] Imported 12 CGM statistics`

## Post-Deploy Actions
- Deploy to HA and let run for ~1 week
- Watch HA log (`/config/home-assistant.log`) for `[Tandem]` lines at INFO level
- Key things to verify:
  - `Poll: no new pump data` lines appear every ~5 min (loop is running)
  - `New pump data` lines appear every 5–15 min (pump is syncing to cloud)
  - `pump_events=OK` is consistently present (not MISSING)
  - `stale_check=False` most of the time
  - CGM age stays under 15 min
- After the week: revert this branch or re-enable staleness in a follow-up PR

## Test Plan
- [x] 338 tests pass locally
- [x] ruff lint + format pass
- [ ] CI green
- [ ] Deploy to HA and observe `[Tandem]` INFO log lines

## Note on upstream
`yo-han/Home-Assistant-Carelink` has a blocking-call fix (Feb 27) worth a separate PR:
`httpx.AsyncClient()` calls `ssl.SSLContext.load_verify_locations()` which blocks the event loop.
Fix: `asyncio.to_thread(httpx.AsyncClient)` in `api.py` and `nightscout_uploader.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)