### PR TITLE
docs: v1.2.3 production release — README rewrite + release blockers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - develop
 
+## [1.2.3] - 2026-03-06
+
+### Added
+- **`carelink.import_history` service action** — recover missed pump statistics from
+  Developer Tools → Actions; specify a date range to backfill CGM glucose, IOB, and
+  basal rate long-term statistics; fetches in 7-day chunks; idempotent and safe to re-run
+
+### Changed
+- **Sensors always show last-known value** — removed 30-minute staleness timeout;
+  sensors no longer go "unavailable" when the app hasn't synced recently; use the
+  `Last pump upload` timestamp to see when data was last refreshed
+- **Integration display name** updated to "Tandem t:slim Pump" in Settings → Devices & Services
+  (was showing the internal domain name "carelink")
+- **Poll log moved to DEBUG** — routine "no new data" message was firing 288×/day at INFO
+  level; now only appears when debug logging is explicitly enabled
+
 ## [1.2.2] - 2026-03-02
 
 ### Fixed
@@ -199,6 +215,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for Guardian Connect CGM
 - Nightscout upload capability
 
+[1.2.3]: https://github.com/jnctech/ha-tandem-pump/compare/v1.2.2...v1.2.3
+[1.2.2]: https://github.com/jnctech/ha-tandem-pump/compare/v1.2.1...v1.2.2
 [1.2.1]: https://github.com/jnctech/ha-tandem-pump/compare/v1.2.0...v1.2.1
 [1.2.0]: https://github.com/jnctech/ha-tandem-pump/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/jnctech/ha-tandem-pump/compare/v1.0.0...v1.1.0

--- a/README.md
+++ b/README.md
@@ -2,53 +2,58 @@
 
 [![release](https://img.shields.io/github/v/release/jnctech/ha-tandem-pump)](https://github.com/jnctech/ha-tandem-pump/releases)
 [![HACS Custom](https://img.shields.io/badge/HACS-Custom-41BDF5.svg)](https://github.com/hacs/integration)
-[![project stage](https://img.shields.io/badge/project%20stage-production%20ready-brightgreen.svg)](https://github.com/jnctech/ha-tandem-pump)
-[![downloads](https://img.shields.io/github/downloads/jnctech/ha-tandem-pump/total)](https://github.com/jnctech/ha-tandem-pump/releases)
-
-[![commits since latest release](https://img.shields.io/github/commits-since/jnctech/ha-tandem-pump/latest)](https://github.com/jnctech/ha-tandem-pump/commits/develop)
-[![commit activity](https://img.shields.io/github/commit-activity/m/jnctech/ha-tandem-pump)](https://github.com/jnctech/ha-tandem-pump/commits/develop)
 [![build](https://img.shields.io/github/actions/workflow/status/jnctech/ha-tandem-pump/ci.yml?branch=develop&label=build)](https://github.com/jnctech/ha-tandem-pump/actions/workflows/ci.yml)
 [![License](https://img.shields.io/github/license/jnctech/ha-tandem-pump)](LICENSE)
 
-**The most comprehensive Tandem insulin pump integration for Home Assistant.** Monitor your Tandem t:slim X2 pump with **45+ sensors**, long-term statistics, glucose history graphs, insulin delivery tracking, pump settings, and full basal profile visibility — all directly in your smart home.
+**45+ sensors from your Tandem t:slim X2 insulin pump — live glucose, IOB, Control-IQ status, basal profile, and long-term statistics — directly in Home Assistant.** No Nightscout relay required.
 
 [![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=jnctech&repository=ha-tandem-pump&category=integration)
 
 ---
 
-## Why This Integration?
+## Features
 
-If you use a **Tandem t:slim X2** insulin pump with Home Assistant, this is the only integration that gives you direct access to your pump data. No Nightscout relay, no third-party cloud — just your Tandem Source account connected straight to HA.
-
-- **45 sensors** covering glucose, insulin delivery, pump status, CGM stats, and pump settings
-- **Long-term statistics** — glucose, IOB, and basal rate imported into HA's statistics engine for native Statistics Graph cards
-- **Last-known value** — sensors always show the most recent reading, even if the pump hasn't synced recently
-- **Smart polling** — skips expensive API calls when no new data exists, reducing token usage
-- **Computed summaries** — TIR, average glucose, GMI, daily insulin totals all computed locally from your pump events
-- **Full pump settings** — see your active profile, basal schedule, Control-IQ config, alert thresholds
-- **Manual backfill** — `carelink.import_history` action lets you fill gaps if the mobile app was not syncing
+- 🩸 **Live CGM readings** — glucose (mmol/L + mg/dL), delta, Time in Range, GMI, SD, CV
+- 💉 **Insulin delivery** — IOB, basal rate, last bolus, TDI, daily bolus/basal totals
+- ⚙️ **Control-IQ status** — open/closed loop mode, activity mode (Sleep/Exercise), pump suspended
+- 📋 **Full pump settings** — active basal profile with schedule, CIQ config, alert thresholds
+- 📈 **Long-term statistics** — CGM glucose, IOB, and basal rate in HA's statistics engine for Statistics Graph cards
+- 🕐 **Last-known value** — sensors always show the most recent reading; no "unavailable" gaps between syncs
+- ⚡ **Smart polling** — skips the full API fetch when the pump hasn't uploaded since last poll
+- 🔄 **Manual backfill** — `carelink.import_history` action recovers missed statistics for any date range
 
 ---
 
-## Sensors at a Glance
+## Sensors (45)
 
-### Glucose Monitoring (10 sensors)
+| Category | Count | Includes |
+|---|---|---|
+| Glucose Monitoring | 10 | CGM readings, delta, avg glucose, TIR, time below/above range, SD, CV, GMI |
+| Insulin Delivery | 10 | IOB, basal rate, last bolus/meal, TDI, daily totals, carbs, bolus count |
+| Pump Status | 7 | Control-IQ mode, activity mode, suspended state, cartridge level, site/cartridge/tubing changes |
+| Pump Settings | 11 | Active basal profile + schedule, CIQ config, max bolus/basal limits, CGM + BG alert thresholds |
+| Device & Timestamps | 7 | Last glucose update, last upload, serial, model, software version, CGM usage |
+
+<details>
+<summary>Full sensor list</summary>
+
+### Glucose Monitoring (10)
 | Sensor | Description |
-|--------|-------------|
+|---|---|
 | Last glucose (mmol/L) | Latest CGM reading in mmol/L |
 | Last glucose (mg/dL) | Latest CGM reading in mg/dL |
 | Glucose delta | Change since previous reading |
-| Average glucose (mmol/L) | Daily average (computed from CGM events) |
-| Average glucose (mg/dL) | Daily average (computed from CGM events) |
+| Average glucose (mmol/L) | Daily average computed from CGM events |
+| Average glucose (mg/dL) | Daily average computed from CGM events |
 | Time in Range | % of readings 70–180 mg/dL |
 | Time below range | % of readings below 70 mg/dL |
 | Time above range | % of readings above 180 mg/dL |
 | Glucose SD / CV | Standard deviation and coefficient of variation |
 | GMI | Glucose Management Indicator |
 
-### Insulin Delivery (10 sensors)
+### Insulin Delivery (10)
 | Sensor | Description |
-|--------|-------------|
+|---|---|
 | Active insulin (IOB) | Insulin on board |
 | Basal rate | Current basal rate (U/hr) |
 | Last bolus | Most recent bolus amount and timestamp |
@@ -59,9 +64,9 @@ If you use a **Tandem t:slim X2** insulin pump with Home Assistant, this is the 
 | Daily carbs | Total carbs entered today |
 | Last carb entry | Most recent carb entry with timestamp |
 
-### Pump Status (7 sensors)
+### Pump Status (7)
 | Sensor | Description |
-|--------|-------------|
+|---|---|
 | Control-IQ status | Open Loop / Closed Loop |
 | Activity mode | Normal / Sleep / Exercise / Eating Soon |
 | Pump suspended | Suspended / Active |
@@ -70,9 +75,9 @@ If you use a **Tandem t:slim X2** insulin pump with Home Assistant, this is the 
 | Last site change | Timestamp (derived from cartridge fill) |
 | Last tubing change | Timestamp of last tubing prime |
 
-### Pump Settings (11 sensors)
+### Pump Settings (11)
 | Sensor | Description |
-|--------|-------------|
+|---|---|
 | Active basal profile | Profile name with full schedule as attributes |
 | Control-IQ enabled | On / Off |
 | Control-IQ weight | Configured weight (kg) |
@@ -83,9 +88,9 @@ If you use a **Tandem t:slim X2** insulin pump with Home Assistant, this is the 
 | BG high/low thresholds | BG alert thresholds (mg/dL) |
 | Low insulin alert | Low reservoir threshold (units) |
 
-### Device Info & Timestamps (7 sensors)
+### Device Info & Timestamps (7)
 | Sensor | Description |
-|--------|-------------|
+|---|---|
 | Last glucose update | When the last CGM reading was received |
 | Last pump upload | When the pump last uploaded to Tandem Source |
 | Last update | Integration data refresh timestamp |
@@ -94,13 +99,9 @@ If you use a **Tandem t:slim X2** insulin pump with Home Assistant, this is the 
 | Software version | Firmware version |
 | CGM usage | Percentage of time CGM was active |
 
-### Long-Term Statistics
-Three metrics are imported into HA's statistics engine on every poll cycle that contains new data:
-- **CGM glucose** — for native Statistics Graph cards
-- **Insulin on board (IOB)** — track IOB trends over days/weeks
-- **Basal rate** — monitor basal delivery patterns
+</details>
 
-Use the [`carelink.import_history` action](#actions) to backfill statistics for any days where the app was not syncing.
+**Long-term statistics** — CGM glucose, IOB, and basal rate are imported into HA's statistics engine on every sync. Use native Statistics Graph cards for daily/weekly/monthly trends, or backfill gaps with [`carelink.import_history`](#actions).
 
 ---
 
@@ -108,96 +109,37 @@ Use the [`carelink.import_history` action](#actions) to backfill statistics for 
 
 ### HACS (Recommended)
 
-[![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=jnctech&repository=ha-tandem-pump&category=integration)
+Click the button above, or manually:
+1. HACS → Integrations → ⋮ → **Custom repositories** → add `https://github.com/jnctech/ha-tandem-pump` (category: Integration)
+2. Find **"Tandem t:slim Pump"**, click **Download**, then restart Home Assistant
 
-Or manually:
-1. Open **HACS** in Home Assistant
-2. Go to **Integrations** > **3-dot menu** > **Custom repositories**
-3. Add: `https://github.com/jnctech/ha-tandem-pump`
-4. Category: **Integration**
-5. Click **Add**, find **"Tandem t:slim Pump"** and click **Download**
-6. Restart Home Assistant
+### Manual
 
-### Manual Installation
-
-Copy `custom_components/carelink/` to your HA `config/custom_components/` directory and restart.
+Copy `custom_components/carelink/` into your HA `config/custom_components/` directory and restart.
 
 ---
 
 ## Configuration
 
-1. **Settings** > **Devices & Services** > **Add Integration**
+1. **Settings → Devices & Services → Add Integration**
 2. Search for **"Carelink"**
-3. Select **Tandem t:slim** as platform
-4. Enter your **Tandem Source** email, password, and region (EU/US)
+3. Select **Tandem t:slim** as the platform
+4. Enter your **Tandem Source** email, password, and region (EU / US)
 5. Set scan interval (default: 300 seconds)
 
-### Prerequisites
-- A **Tandem t:slim X2** pump syncing to [Tandem Source](https://source.tandemdiabetes.com)
-- The **Tandem t:slim mobile app** installed, paired to your pump, and running with background activity permitted (see below)
-- Home Assistant **2023.1.0** or later
+**Prerequisites:** A Tandem t:slim X2 pump syncing to [Tandem Source](https://source.tandemdiabetes.com) via the Tandem t:slim mobile app, and Home Assistant **2023.1.0+**.
 
 ---
 
-## Mobile App & Sync Reliability
+## Mobile App & Sync
 
-**This integration depends entirely on the Tandem t:slim mobile app** to upload pump data to Tandem Source. The integration reads from Tandem Source — it cannot talk to your pump directly. If the app is restricted by battery management, your HA sensors will continue showing the last known values but will not update until the app syncs again.
+Data flows: **Pump → Tandem t:slim app → Tandem Source cloud → This integration → HA**
 
-### How often does data sync?
+The app uploads pump data approximately **every 60 minutes** when unrestricted. HA picks up new data within minutes of each upload.
 
-Based on real-world observation, when the app is unrestricted:
-
-- The app uploads pump data to Tandem Source approximately **every 60 minutes**
-- HA polls every 5 minutes and detects new data within a few minutes of each upload
-- A typical sync cycle produces ~600–1,000 CGM readings and ~1,000 basal statistics entries
-
-> The app must be **connected to your pump via Bluetooth** for uploads to occur. Keep the phone nearby with Bluetooth on.
-
-### Android — Recommended Settings
-
-Modern Android aggressively restricts background apps to save battery. The Tandem app **must** be set to unrestricted battery usage:
-
-**1. Set battery mode to Unrestricted**
-- Go to **Settings → Apps → Tandem t:slim → Battery**
-- Set to **Unrestricted** (the default is "Optimised" which will pause background sync)
-
-**2. Check manufacturer-specific restrictions**
-
-Many Android manufacturers add their own battery management on top of Android's defaults:
-
-| Manufacturer | Where to look |
-|-------------|---------------|
-| Samsung (One UI) | Settings → Battery → Background usage limits → ensure Tandem is not listed as "sleeping" or "deep sleeping" |
-| Xiaomi / MIUI | Settings → Battery → App battery saver → set Tandem to "No restrictions" |
-| OnePlus / OxygenOS | Settings → Battery → Battery optimisation → Tandem → Don't optimise |
-| Huawei / EMUI | Phone Manager → Power saving → Protected apps → enable Tandem |
-| Google Pixel | Settings → Apps → Tandem t:slim → Battery → Unrestricted |
-
-**3. Disable battery optimisation (all Android)**
-- Go to **Settings → Battery → Battery optimisation** (or search "Battery optimisation")
-- Find Tandem t:slim and set to **Don't optimise**
-
-> **Tip:** If data gaps still appear after applying these settings, check if **Adaptive Battery** or **Device Health Services** is re-restricting the app. On some devices you may need to disable adaptive battery entirely.
-
-### iOS — Recommended Settings
-
-**1. Enable Background App Refresh**
-- Go to **Settings → General → Background App Refresh**
-- Ensure it is **On** globally, and that **Tandem t:slim** is enabled in the list
-
-**2. Avoid Low Power Mode during critical periods**
-- **Settings → Battery → Low Power Mode** — when enabled, iOS pauses background refresh for all apps
-- Disable Low Power Mode when you need continuous syncing (e.g. overnight monitoring)
-
-**3. Do not force-quit the app**
-- Force-quitting an app from the app switcher prevents iOS from ever waking it in the background
-- Instead, just lock the screen and let iOS manage it
-
-> **Note:** iOS is generally more reliable for background sync than Android once Background App Refresh is enabled.
-
-### If data gaps appear
-
-Use the [`carelink.import_history` action](#actions) to backfill any days where the app was not syncing. The action is idempotent — running it for a range that partially has data will fill the gaps without affecting what is already there.
+- **Android:** Set Tandem t:slim to **Unrestricted** battery usage (Settings → Apps → Tandem t:slim → Battery). Most manufacturers add extra restrictions — [full per-manufacturer settings →](TROUBLESHOOTING.md#mobile-app-settings)
+- **iOS:** Enable **Background App Refresh** (Settings → General → Background App Refresh → Tandem t:slim: On). Avoid Low Power Mode. Do not force-quit the app.
+- **Data gaps:** Use `carelink.import_history` to recover missed statistics after fixing app settings.
 
 ---
 
@@ -205,84 +147,38 @@ Use the [`carelink.import_history` action](#actions) to backfill any days where 
 
 ### `carelink.import_history`
 
-Manually imports pump events for a specified date range as long-term statistics (CGM glucose, active insulin, and basal rate). This is the primary recovery tool for periods when the Tandem app was not syncing in the background.
+Backfill long-term statistics (CGM glucose, IOB, basal rate) for any date range where the Tandem app was not syncing.
 
-**To use:** Go to **Developer Tools → Actions** in Home Assistant, search for `carelink.import_history`, set your date range, and click **Perform action**.
+**Developer Tools → Actions → search `carelink.import_history`**
 
 | Field | Required | Description |
-|-------|----------|-------------|
-| `start_date` | ✅ Yes | First date to import (date picker or YYYY-MM-DD) |
-| `end_date` | No | Last date to import (date picker or YYYY-MM-DD). Defaults to today if not set |
+|---|---|---|
+| `start_date` | ✅ | First date to import (date picker or YYYY-MM-DD) |
+| `end_date` | — | Last date to import. Defaults to today |
 
-**How it works:**
-- The date range is fetched in 7-day chunks to avoid API timeouts on large requests
-- Each chunk calls the Tandem Source pump events API and imports any CGM, IOB, and basal rate statistics found
-- If a chunk fails (e.g. network timeout), it is logged and skipped — remaining chunks continue
-- Running the same range multiple times is **safe and idempotent** — existing statistics are updated with the same values, missing hours are filled in
-
-**Recommended usage:**
+- Fetches in 7-day chunks — safe on large date ranges
+- **Idempotent** — running the same range twice is safe; gaps are filled, existing data is unchanged
+- Recommended max per run: **1 month**
 
 | Scenario | Suggested range |
-|----------|----------------|
-| App was backgrounded for a day | yesterday → today |
+|---|---|
+| App backgrounded for a day | yesterday → today |
 | App not syncing for a week | 7 days ago → today |
-| Initial backfill after first install | integration start date → today (run in monthly chunks for best reliability) |
-| First install — fill all available history | Use `minDateWithEvents` from pump metadata as start date; run 1 month at a time |
-
-> **Maximum single run:** Up to **1 month** is recommended per action call. Larger ranges will work but take longer. There is no HA session timeout — the action runs in the background.
+| First install — full backfill | integration start date → today (run in monthly chunks) |
 
 ---
 
 ## Dashboard
 
-A starter dashboard YAML with ApexCharts glucose and insulin graphs is included at [`examples/dashboard.yaml`](examples/dashboard.yaml). It provides:
-- Live glucose display with trend arrow
-- 24-hour glucose history graph (pump CGM overlay)
-- Insulin delivery graph (bolus + basal)
-- All sensor values in a grid
+A starter dashboard with ApexCharts glucose and insulin graphs is at [`examples/dashboard.yaml`](examples/dashboard.yaml).
 
 ---
 
-## How It Works
+## Troubleshooting & Support
 
-This integration connects to the **Tandem Source Reports API** — the same API that powers the Tandem Source website. It decodes the proprietary binary pump event format (26-byte records with Tandem epoch timestamps) to extract all sensor data.
+See [TROUBLESHOOTING.md](TROUBLESHOOTING.md) for installation issues, authentication errors, missing sensors, Nightscout setup, and debug logging.
 
-**Data flow:** Pump → Tandem t:slim mobile app → Tandem Source cloud → This integration → Home Assistant
-
-The integration polls every 5 minutes (configurable) and:
-1. Checks lightweight metadata to see if new data exists (skips the full fetch if the pump hasn't uploaded since last poll)
-2. Fetches binary pump events (15 event types) when new data is available
-3. Decodes events, computes daily summaries, extracts pump settings
-4. Imports long-term statistics for HA's native graph cards
-5. Sensors always show the most recent value received — use the `Last pump upload` sensor to see when data was last refreshed
-
----
-
-## Medtronic Carelink Support
-
-This integration was forked from [@yo-han's Carelink integration](https://github.com/yo-han/Home-Assistant-Carelink). The Medtronic Carelink code path is preserved but **has not been tested** under this fork. If you use a Medtronic pump, please use the [original repository](https://github.com/yo-han/Home-Assistant-Carelink) for verified support.
-
----
-
-## Optional: Nightscout
-
-The integration can optionally upload glucose data to a [Nightscout](http://www.nightscout.info/) instance. Configure the Nightscout URL and API secret in the integration options. See [TROUBLESHOOTING.md](TROUBLESHOOTING.md) for Nightscout setup details.
-
----
-
-## Troubleshooting
-
-See [TROUBLESHOOTING.md](TROUBLESHOOTING.md) for common issues including:
-- Integration not loading
-- Authentication failures
-- Sensors stuck on "Unknown"
-- Data not updating
-
----
-
-## Contributing
-
-Contributions welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, branch strategy, and testing requirements.
+Open an issue: https://github.com/jnctech/ha-tandem-pump/issues
 
 ---
 
@@ -290,5 +186,6 @@ Contributions welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for development se
 
 - Tandem Source integration by [@jnctech](https://github.com/jnctech)
 - Original Carelink integration by [@yo-han](https://github.com/yo-han/Home-Assistant-Carelink)
-- Carelink API based on work by [@ondrej1024](https://github.com/ondrej1024)
 - Binary event format reference from [tconnectsync](https://github.com/jwoglom/tconnectsync) by [@jwoglom](https://github.com/jwoglom)
+
+> **Medtronic Carelink:** The Medtronic code path is preserved from the original fork but has not been tested under this fork. For verified Medtronic support use the [original repository](https://github.com/yo-han/Home-Assistant-Carelink).

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -1,22 +1,75 @@
 # Troubleshooting Guide
 
-Common issues and solutions for the Tandem Source / Carelink integration.
+Common issues and solutions for the Tandem t:slim Pump integration.
+
+---
+
+## Mobile App Settings {#mobile-app-settings}
+
+This integration reads from the **Tandem Source cloud** — it cannot communicate with your pump directly. The **Tandem t:slim mobile app** must be running in the background and connected to your pump via Bluetooth for uploads to occur.
+
+When unrestricted, the app uploads pump data approximately **every 60 minutes**. HA picks up new data within minutes of each upload.
+
+### Android — Battery Settings
+
+Modern Android aggressively restricts background apps. The Tandem app **must** be set to unrestricted battery usage:
+
+**1. Set battery mode to Unrestricted**
+- Go to **Settings → Apps → Tandem t:slim → Battery**
+- Set to **Unrestricted** (the default "Optimised" mode pauses background sync)
+
+**2. Disable battery optimisation**
+- Go to **Settings → Battery → Battery optimisation**
+- Find Tandem t:slim and set to **Don't optimise**
+
+**3. Manufacturer-specific restrictions**
+
+Many manufacturers add extra battery management on top of Android defaults:
+
+| Manufacturer | Setting to change |
+|---|---|
+| Samsung (One UI) | Settings → Battery → Background usage limits → ensure Tandem is not "sleeping" or "deep sleeping" |
+| Xiaomi / MIUI | Settings → Battery → App battery saver → set Tandem to "No restrictions" |
+| OnePlus / OxygenOS | Settings → Battery → Battery optimisation → Tandem → Don't optimise |
+| Huawei / EMUI | Phone Manager → Power saving → Protected apps → enable Tandem |
+| Google Pixel | Settings → Apps → Tandem t:slim → Battery → Unrestricted |
+
+> **Tip:** If data gaps still appear after applying these settings, check if **Adaptive Battery** is re-restricting the app. On some devices you may need to disable Adaptive Battery entirely.
+
+### iOS — Background App Refresh
+
+**1. Enable Background App Refresh**
+- Go to **Settings → General → Background App Refresh**
+- Ensure it is **On** globally, and that **Tandem t:slim** is enabled in the list
+
+**2. Avoid Low Power Mode during monitoring periods**
+- **Settings → Battery → Low Power Mode** — when enabled, iOS pauses background refresh for all apps
+- Disable Low Power Mode when continuous syncing is needed (e.g. overnight)
+
+**3. Do not force-quit the app**
+- Force-quitting from the app switcher prevents iOS from ever waking the app in the background
+- Lock the screen instead and let iOS manage it
+
+> iOS is generally more reliable for background sync than Android once Background App Refresh is enabled.
+
+### If data gaps appear
+
+Use the `carelink.import_history` action (Developer Tools → Actions) to backfill any missed statistics. The action is idempotent — running it over a range that already has partial data fills the gaps without overwriting existing values.
+
+---
 
 ## Installation Issues
 
 ### Integration Not Appearing in HACS
 
-**Symptoms**: Can't find "Carelink" in HACS integration list
+**Symptoms**: Can't find "Tandem t:slim Pump" or "Carelink" in HACS integration list
 
 **Solutions**:
 1. Ensure custom repository is added correctly:
    - URL: `https://github.com/jnctech/ha-tandem-pump`
    - Category: Integration
-
 2. Restart Home Assistant after adding repository
-
-3. Clear HACS cache:
-   - HACS → 3-dot menu → Custom repositories → Reload
+3. Clear HACS cache: HACS → 3-dot menu → Custom repositories → Reload
 
 ### Integration Won't Load After Installation
 
@@ -32,29 +85,12 @@ config/
         ├── manifest.json
         └── [other files]
 ```
-
-2. Check Home Assistant logs:
-   - Settings → System → Logs
-   - Look for errors mentioning "carelink"
-
+2. Check Home Assistant logs: Settings → System → Logs — look for errors mentioning "carelink"
 3. Restart Home Assistant fully (not just reload)
 
+---
+
 ## Configuration Issues
-
-### "Invalid handler specified" Error (v0.1.0.beta only)
-
-**Symptoms**: Config flow crashes with "Invalid handler specified"
-
-**Solution**: This was a bug in v0.1.0.beta. Upgrade to v0.1.3-beta or later.
-
-### SSL Certificate Errors
-
-**Symptoms**: Integration fails to load with SSL or certificate errors
-
-**Solution**:
-- Fixed in v0.1.3-beta
-- Ensure you're running v0.1.3-beta or later
-- Check `custom_components/carelink/manifest.json` contains `"certifi>=2023.0.0"` in requirements
 
 ### Authentication Fails
 
@@ -64,13 +100,12 @@ config/
 1. Verify credentials work at https://source.tandemdiabetes.com (US) or https://source.eu.tandemdiabetes.com (EU)
 2. Ensure correct region selected (US/EU)
 3. Check for typos in email/password
-4. MFA/2FA not supported - ensure it's disabled
+4. MFA/2FA not supported — ensure it is disabled on your Tandem Source account
 
 **Medtronic Carelink**:
 1. Verify credentials work at https://carelink.minimed.eu
 2. MFA must be disabled
 3. Must use care partner account for pumps
-4. Guardian Connect may work with patient account
 
 ### Wrong Region Selected
 
@@ -82,57 +117,45 @@ config/
    - US: source.tandemdiabetes.com
    - EU: source.eu.tandemdiabetes.com
 
+---
+
 ## Data Issues
 
-### All Sensors Show "Unknown"
+### All Sensors Show "Unknown" or "Unavailable"
 
-**Symptoms**: Integration loads, but all sensors show "Unknown" or "Unavailable"
+**Possible causes**:
 
-**Most Likely Cause** (Tandem, v0.1.3-beta and earlier):
-The ControlIQ API endpoints return 404 errors, leaving all sensors unpopulated. **Upgrade to the latest version** which uses the Source Reports pumpevents API instead.
+1. **No recent data from pump** — ensure pump has synced to Tandem Source recently (check the Source website). See [Mobile App Settings](#mobile-app-settings) above.
 
-**Other Possible Causes**:
+2. **API authentication expired** — wait for next polling cycle (default 5 minutes) or restart the integration
 
-1. **No recent data from pump**
-   - Ensure pump has synced to Source recently (check Source website)
-   - Tandem pumps sync when connected to phone with Tandem t:slim mobile app
-
-2. **API authentication expired**
-   - Wait for next polling cycle (default: 5 minutes)
-   - Or restart integration
-
-3. **Missing tconnectDeviceId** (Tandem only)
-   - If pump_metadata doesn't contain a `tconnectDeviceId`, the integration cannot fetch pump events
-   - Check logs for "No tconnectDeviceId in metadata"
-   - This usually means the pump hasn't uploaded to Tandem Source yet
+3. **Missing tconnectDeviceId** (Tandem only) — if pump metadata doesn't contain a `tconnectDeviceId`, the integration cannot fetch pump events. Usually means the pump hasn't uploaded to Tandem Source yet. Check logs for "No tconnectDeviceId in metadata".
 
 ### Sensors Not Updating / Delayed Updates
 
-**Symptoms**: Sensors show old data, updates take longer than the configured scan interval
-
-**Expected Behavior**:
-- Integration polls API every 5 minutes (default scan interval)
-- Not real-time — depends on pump sync frequency via Tandem t:slim mobile app
-- Adjust scan interval in configuration if needed (60–900 seconds)
+**Expected behaviour**:
+- Integration polls every 5 minutes (configurable)
+- Not real-time — depends on pump sync frequency via the Tandem t:slim app
+- Sensors always show the **last known value** — they do not go unavailable between syncs
 
 **If updates are slower than expected**:
-1. **Check logs for transient errors**: Enable debug logging and look for `Tandem: transient error` messages. The integration retries failed API calls automatically (up to 2 retries with 2s/4s backoff).
-2. **Check for `UpdateFailed` messages**: If the coordinator reports `UpdateFailed`, Home Assistant will use exponential backoff before retrying. This is normal recovery behaviour after network issues.
-3. **Timezone mismatch**: If your HA server is in a different timezone to your pump, ensure the integration's configured timezone matches the pump's timezone. The API date range uses this to avoid missing recent data.
-4. **Network stability**: Unstable connections can trigger retries. Check your HA server's network connectivity to `source.eu.tandemdiabetes.com` (EU) or `source.tandemdiabetes.com` (US).
+1. Check [Mobile App Settings](#mobile-app-settings) — battery restrictions are the most common cause
+2. Enable debug logging and look for transient error messages (see [Enable Debug Logging](#enable-debug-logging))
+3. Use `carelink.import_history` to backfill any statistics gaps after fixing the app settings
 
 ### Missing Sensors
 
 **Symptoms**: Some expected sensors not appearing
 
 **Tandem Pumps**:
-- If ControlIQ sensors (basal rate, IOB) are missing, this is expected
-- Source OIDC tokens may not grant access to ControlIQ API
-- Check logs for "ControlIQ therapy timeline not available"
+- All 45 sensors are populated from the Tandem Source Reports API — no ControlIQ API access required
+- If sensors are missing, check HA logs for parsing errors and ensure the pump has recent data on Tandem Source
 
 **Medtronic Pumps**:
 - Ensure pump model is supported (770G, 780G)
-- Guardian Connect CGM users may have limited sensor set
+- Guardian Connect CGM users may have a limited sensor set
+
+---
 
 ## Nightscout Integration
 
@@ -142,53 +165,34 @@ The ControlIQ API endpoints return 404 errors, leaving all sensors unpopulated. 
 
 **Solutions**:
 
-1. **Verify Nightscout is accessible**
-   - Open Nightscout URL in browser
-   - Should see dashboard
+1. **Verify Nightscout is accessible** — open Nightscout URL in browser; you should see the dashboard
 
 2. **Check API Secret**
-   - Must be at least 12 characters
-   - Case-sensitive
-   - No spaces or special characters
+   - Must be at least 12 characters, case-sensitive, no spaces or special characters
 
 3. **Verify URL format**
    - Must include protocol: `http://` or `https://`
-   - No trailing slash
-   - Example: `http://192.168.1.100:1337`
+   - No trailing slash — example: `http://192.168.1.100:1337`
 
-4. **Network connectivity**
-   - If HA is in Docker, ensure containers can communicate
-   - Use container name if on same Docker network: `http://nightscout:1337`
-   - Use host IP for external access
+4. **Network connectivity** — if HA is in Docker, use the container name: `http://nightscout:1337`
 
-5. **Check Home Assistant logs**
-   - Look for Nightscout upload errors
-   - May show authentication or network issues
+5. Check Home Assistant logs for Nightscout upload errors
+
+---
 
 ## Performance Issues
 
 ### High CPU Usage
 
-**Symptoms**: Home Assistant slow, high CPU usage when integration is active
-
 **Solutions**:
-1. Increase scan interval (default 300s):
-   - Settings → Devices & Services → Carelink → Configure
-   - Increase to 600 or 900 seconds
+1. Increase scan interval: Settings → Devices & Services → Carelink → Configure → increase to 600 or 900 seconds
+2. Remove debug logging if enabled
 
-2. Check for excessive logging:
-   - Remove debug logging if enabled
-   - Settings → System → Logs
-
-### Blocking Call Warning (Pre-v0.1.3-beta)
-
-**Symptoms**: Log shows "Detected blocking call to load_verify_locations"
-
-**Solution**: Upgrade to v0.1.3-beta or later. This was fixed in v0.1.3-beta.
+---
 
 ## Diagnostic Steps
 
-### Enable Debug Logging
+### Enable Debug Logging {#enable-debug-logging}
 
 Add to `configuration.yaml`:
 
@@ -210,59 +214,19 @@ Restart Home Assistant, then check logs for detailed information.
 
 ### Check Integration Version
 
-1. HACS → Integrations → Carelink
-2. Version shown at bottom
-3. Or check `custom_components/carelink/manifest.json`
+1. HACS → Integrations → Carelink — version shown at bottom
+2. Or check `custom_components/carelink/manifest.json`
 
-### Verify Installation Integrity
-
-```bash
-# Check all required files exist
-ls config/custom_components/carelink/
-# Should show: __init__.py, manifest.json, api.py, tandem_api.py, etc.
-
-# Check manifest version
-cat config/custom_components/carelink/manifest.json | grep version
-```
+---
 
 ## Getting Help
 
 If issues persist:
 
 1. **Check existing issues**: https://github.com/jnctech/ha-tandem-pump/issues
-2. **Create new issue**:
-   - Include HA version
-   - Include integration version
-   - Include relevant logs (remove sensitive data)
-   - Include diagnostic report
-3. **Provide details**:
-   - Platform type (Tandem/Carelink)
-   - Region (US/EU)
+2. **Create new issue** — include:
+   - HA version and integration version
+   - Platform (Tandem/Carelink) and region (US/EU)
    - Pump model
-   - When issue started
-   - What you've already tried
-
-## Known Issues
-
-### v0.2.0-rc1
-
-**Resolved**: Primary sensor population now works via Source Reports pumpevents API.
-
-**Added**: Historical data import with state replay and long-term statistics.
-
-**Remaining** (Issue #5): The following sensors still show "Unknown":
-- **Average Glucose, Time in Range, CGM Usage**: Require dashboard_summary from ControlIQ API (returns 404). Planned fix: compute from CGM event history.
-- **Last Pump Upload, Last Update**: Metadata timestamp parsing not yet implemented. Quick fix available.
-- **Last Glucose Delta**: Self-resolving - requires two update cycles to calculate.
-
-### v0.1.3-beta
-
-- ControlIQ API (`tdcservices.eu.tandemdiabetes.com`) returns 404 with Source OIDC tokens
-- All Tandem sensors stuck in "Unknown" state (fixed in unreleased - PR #4)
-- Fix switches to Source Reports pumpevents API as primary data source
-
-### v0.1.0.beta (DEPRECATED - DO NOT USE)
-
-- Critical bug: "Invalid handler specified" error
-- Integration fails to load
-- Use v0.1.3-beta instead
+   - Relevant logs (remove sensitive data)
+   - Diagnostic report download

--- a/custom_components/carelink/manifest.json
+++ b/custom_components/carelink/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "carelink",
-  "name": "carelink",
+  "name": "Tandem t:slim Pump",
   "after_dependencies": ["recorder"],
   "codeowners": ["@jnctech"],
   "config_flow": true,


### PR DESCRIPTION
## Summary
- **README.md** rewritten from 295 → 191 lines; sensor tables collapsed in `<details>`; Android/iOS settings moved to TROUBLESHOOTING.md; SEO keywords in headings
- **CHANGELOG.md** adds v1.2.3 section (last-known-value, import_history, poll log fix) + missing comparison links for v1.2.2 and v1.2.3
- **TROUBLESHOOTING.md** removes stale Known Issues (v0.2.0-rc1/v0.1.3-beta), adds Mobile App Settings section, fixes Missing Sensors Tandem caveat
- **manifest.json** display name: `"carelink"` → `"Tandem t:slim Pump"`

## Post-Deploy Actions
None — documentation and metadata only.

## Test Plan
- [ ] README renders correctly on GitHub (tables, `<details>` collapse, badges, anchor links)
- [ ] CHANGELOG comparison links resolve correctly
- [ ] TROUBLESHOOTING.md no longer mentions v0.2.0-rc1 or v0.1.3-beta
- [ ] After HA restart: Settings → Devices & Services shows "Tandem t:slim Pump" not "carelink"

🤖 Generated with [Claude Code](https://claude.com/claude-code)