### PR TITLE
Fix SonarCloud quality gate badge pointing to wrong project

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ using your existing Tandem Source account. No extra hardware required.
 [![release](https://img.shields.io/github/v/release/jnctech/ha-tandem-pump)](https://github.com/jnctech/ha-tandem-pump/releases)
 [![HACS Custom](https://img.shields.io/badge/HACS-Custom-41BDF5.svg)](https://github.com/hacs/integration)
 [![build](https://img.shields.io/github/actions/workflow/status/jnctech/ha-tandem-pump/ci.yml?branch=develop&label=build)](https://github.com/jnctech/ha-tandem-pump/actions/workflows/ci.yml)
-[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=jnctech_ha_hinen_power&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=jnctech_ha_hinen_power)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=jnctech_ha-tandem-pump&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=jnctech_ha-tandem-pump)
 [![License](https://img.shields.io/github/license/jnctech/ha-tandem-pump)](LICENSE)
 
 [![Add to HACS](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=jnctech&repository=ha-tandem-pump&category=integration)


### PR DESCRIPTION
The badge was referencing jnctech_ha_hinen_power instead of jnctech_ha-tandem-pump, causing it to show a failed status from an unrelated project.

https://claude.ai/code/session_0128mEhNBqmnewvBMdwNH5EL