### PR TITLE
feat(tandem): alerts & alarms sensors (Phase 2)

### DIFF
--- a/custom_components/carelink/__init__.py
+++ b/custom_components/carelink/__init__.py
@@ -139,6 +139,8 @@ from .const import (
     TANDEM_SENSOR_KEY_PUMP_SUSPEND_REASON,
     # Event-derived lookup maps
     CGM_STATUS_MAP,
+    TANDEM_ALERT_MAP,
+    TANDEM_ALARM_MAP,
     # Computed insulin summary
     TANDEM_SENSOR_KEY_TOTAL_DAILY_INSULIN,
     TANDEM_SENSOR_KEY_DAILY_BOLUS_TOTAL,
@@ -164,6 +166,10 @@ from .const import (
     TANDEM_SENSOR_KEY_BATTERY_VOLTAGE,
     TANDEM_SENSOR_KEY_BATTERY_REMAINING_MAH,
     TANDEM_SENSOR_KEY_CHARGING_STATUS,
+    # Alerts & Alarms (Phase 2)
+    TANDEM_SENSOR_KEY_LAST_ALERT,
+    TANDEM_SENSOR_KEY_LAST_ALARM,
+    TANDEM_SENSOR_KEY_ACTIVE_ALERTS_COUNT,
 )
 
 PLATFORMS: list[Platform] = [Platform.SENSOR, Platform.BINARY_SENSOR, Platform.NUMBER]
@@ -1202,6 +1208,9 @@ class TandemCoordinator(DataUpdateCoordinator):
         data[TANDEM_SENSOR_KEY_BATTERY_VOLTAGE] = UNAVAILABLE
         data[TANDEM_SENSOR_KEY_BATTERY_REMAINING_MAH] = UNAVAILABLE
         data[TANDEM_SENSOR_KEY_CHARGING_STATUS] = UNAVAILABLE
+        data[TANDEM_SENSOR_KEY_LAST_ALERT] = UNAVAILABLE
+        data[TANDEM_SENSOR_KEY_LAST_ALARM] = UNAVAILABLE
+        data[TANDEM_SENSOR_KEY_ACTIVE_ALERTS_COUNT] = UNAVAILABLE
 
         if not timeline:
             data[TANDEM_SENSOR_KEY_LASTSG_MMOL] = UNAVAILABLE
@@ -1410,6 +1419,8 @@ class TandemCoordinator(DataUpdateCoordinator):
         daily_basal_events: list[dict] = []
         shelf_mode_events: list[dict] = []
         usb_events: list[dict] = []
+        alert_events: list[dict] = []
+        alarm_events: list[dict] = []
 
         for evt in pump_events:
             eid = evt.get("event_id")
@@ -1447,13 +1458,18 @@ class TandemCoordinator(DataUpdateCoordinator):
                 shelf_mode_events.append(evt)
             elif eid in (36, 37):  # USB_CONNECTED / USB_DISCONNECTED
                 usb_events.append(evt)
+            elif eid in (4, 26):  # ALERT_ACTIVATED / ALERT_CLEARED
+                alert_events.append(evt)
+            elif eid in (5, 6, 28):  # ALARM_ACTIVATED / MALFUNCTION_ACTIVATED / ALARM_CLEARED
+                alarm_events.append(evt)
 
         _LOGGER.debug(
             "Tandem: Events - CGM: %d, BolusCompleted: %d, BolexCompleted: %d, "
             "BolusDelivery: %d, BasalChange: %d, BasalDelivery: %d, "
             "Suspend/Resume: %d, BG: %d, Cartridge: %d, Carbs: %d, "
             "Cannula: %d, Tubing: %d, UserMode: %d, PCM: %d, "
-            "DailyBasal: %d, ShelfMode: %d, USB: %d",
+            "DailyBasal: %d, ShelfMode: %d, USB: %d, "
+            "Alert: %d, Alarm: %d",
             len(cgm_readings),
             len(bolus_completed),
             len(bolex_completed),
@@ -1471,6 +1487,8 @@ class TandemCoordinator(DataUpdateCoordinator):
             len(daily_basal_events),
             len(shelf_mode_events),
             len(usb_events),
+            len(alert_events),
+            len(alarm_events),
         )
 
         # Update the last-seen sequence number for statistics deduplication
@@ -1497,6 +1515,8 @@ class TandemCoordinator(DataUpdateCoordinator):
         daily_basal_events.sort(key=lambda e: e["timestamp"])
         shelf_mode_events.sort(key=lambda e: e["timestamp"])
         usb_events.sort(key=lambda e: e["timestamp"])
+        alert_events.sort(key=lambda e: e["timestamp"])
+        alarm_events.sort(key=lambda e: e["timestamp"])
 
         # ── Populate current sensor values from latest events ────────
 
@@ -1861,6 +1881,21 @@ class TandemCoordinator(DataUpdateCoordinator):
             data[TANDEM_SENSOR_KEY_BATTERY_REMAINING_MAH] = UNAVAILABLE
             data[TANDEM_SENSOR_KEY_CHARGING_STATUS] = UNAVAILABLE
 
+        # ── Alerts & Alarms (Phase 2) ─────────────────────────────────
+        try:
+            self._parse_alert_alarm_events(alert_events, alarm_events, data)
+        except Exception as e:
+            _LOGGER.error(
+                "Error parsing alert/alarm events (%d alert, %d alarm events): %s",
+                len(alert_events),
+                len(alarm_events),
+                e,
+                exc_info=True,
+            )
+            data[TANDEM_SENSOR_KEY_LAST_ALERT] = UNAVAILABLE
+            data[TANDEM_SENSOR_KEY_LAST_ALARM] = UNAVAILABLE
+            data[TANDEM_SENSOR_KEY_ACTIVE_ALERTS_COUNT] = UNAVAILABLE
+
         # ── Computed summaries ─────────────────────────────────────────
         try:
             self._compute_cgm_summary(cgm_readings, data)
@@ -1878,6 +1913,99 @@ class TandemCoordinator(DataUpdateCoordinator):
             )
         except Exception as e:
             _LOGGER.warning("Error computing insulin summary: %s", e, exc_info=True)
+
+    def _parse_alert_alarm_events(
+        self,
+        alert_events: list[dict],
+        alarm_events: list[dict],
+        data: dict,
+    ) -> None:
+        """Parse alert and alarm events into sensor values.
+
+        alert_events contains events 4 (AlertActivated) and 26 (AlertCleared).
+        alarm_events contains events 5 (AlarmActivated), 6 (MalfunctionActivated),
+        and 28 (AlarmCleared).
+
+        Active count tracks all uncleared activations across both lists.
+        """
+        tz = ZoneInfo(self.timezone)
+
+        # ── Alert sensors (events 4 / 26) ────────────────────────────
+        # Track which alert IDs are currently active (activated but not cleared).
+        # Events are pre-sorted by timestamp so we replay in order.
+        active_alerts: dict[int, dict] = {}
+        for evt in alert_events:
+            if evt["event_name"] == "AlertActivated":
+                active_alerts[evt["alert_id"]] = evt
+            elif evt["event_name"] == "AlertCleared":
+                active_alerts.pop(evt["alert_id"], None)
+
+        last_activated_alert = next(
+            (e for e in reversed(alert_events) if e["event_name"] == "AlertActivated"),
+            None,
+        )
+        if last_activated_alert:
+            aid = last_activated_alert["alert_id"]
+            name = TANDEM_ALERT_MAP.get(aid, f"Alert {aid}")
+            ts = last_activated_alert["timestamp"].replace(tzinfo=tz)
+            # Last 10 activation events in order; the same alert_id may appear
+            # multiple times if it fired and cleared repeatedly.
+            recent = [
+                {
+                    "id": e["alert_id"],
+                    "name": TANDEM_ALERT_MAP.get(e["alert_id"], f"Alert {e['alert_id']}"),
+                    "timestamp": e["timestamp"].replace(tzinfo=tz).isoformat(),
+                }
+                for e in alert_events
+                if e["event_name"] == "AlertActivated"
+            ][-10:]
+            data[TANDEM_SENSOR_KEY_LAST_ALERT] = name
+            data[f"{TANDEM_SENSOR_KEY_LAST_ALERT}_attributes"] = {
+                "alert_id": aid,
+                "cleared": aid not in active_alerts,
+                "timestamp": ts.isoformat(),
+                "recent": recent,
+            }
+        else:
+            data[TANDEM_SENSOR_KEY_LAST_ALERT] = UNAVAILABLE
+
+        # ── Alarm sensors (events 5, 6 / 28) ─────────────────────────
+        active_alarms: dict[int, dict] = {}
+        for evt in alarm_events:
+            if evt["event_name"] in ("AlarmActivated", "MalfunctionActivated"):
+                active_alarms[evt["alert_id"]] = evt
+            elif evt["event_name"] == "AlarmCleared":
+                active_alarms.pop(evt["alert_id"], None)
+
+        last_activated_alarm = next(
+            (e for e in reversed(alarm_events) if e["event_name"] in ("AlarmActivated", "MalfunctionActivated")),
+            None,
+        )
+        if last_activated_alarm:
+            aid = last_activated_alarm["alert_id"]
+            name = TANDEM_ALARM_MAP.get(aid, f"Alarm {aid}")
+            ts = last_activated_alarm["timestamp"].replace(tzinfo=tz)
+            recent = [
+                {
+                    "id": e["alert_id"],
+                    "name": TANDEM_ALARM_MAP.get(e["alert_id"], f"Alarm {e['alert_id']}"),
+                    "timestamp": e["timestamp"].replace(tzinfo=tz).isoformat(),
+                }
+                for e in alarm_events
+                if e["event_name"] in ("AlarmActivated", "MalfunctionActivated")
+            ][-10:]
+            data[TANDEM_SENSOR_KEY_LAST_ALARM] = name
+            data[f"{TANDEM_SENSOR_KEY_LAST_ALARM}_attributes"] = {
+                "alert_id": aid,
+                "cleared": aid not in active_alarms,
+                "timestamp": ts.isoformat(),
+                "recent": recent,
+            }
+        else:
+            data[TANDEM_SENSOR_KEY_LAST_ALARM] = UNAVAILABLE
+
+        # ── Active count (alerts + alarms combined) ───────────────────
+        data[TANDEM_SENSOR_KEY_ACTIVE_ALERTS_COUNT] = len(active_alerts) + len(active_alarms)
 
     def _parse_dashboard_summary(self, summary: dict | None, data: dict) -> None:
         """Parse dashboard summary into sensor values."""

--- a/custom_components/carelink/const.py
+++ b/custom_components/carelink/const.py
@@ -534,6 +534,11 @@ TANDEM_SENSOR_KEY_CGM_STATUS = "tandem_cgm_status"
 TANDEM_SENSOR_KEY_LAST_CARTRIDGE_FILL = "tandem_last_cartridge_fill_amount"
 TANDEM_SENSOR_KEY_PUMP_SUSPEND_REASON = "tandem_pump_suspend_reason"
 
+# ── Alerts & Alarms keys (Phase 2 — from events 4, 5, 6, 26, 28) ──────
+TANDEM_SENSOR_KEY_LAST_ALERT = "tandem_last_alert"
+TANDEM_SENSOR_KEY_LAST_ALARM = "tandem_last_alarm"
+TANDEM_SENSOR_KEY_ACTIVE_ALERTS_COUNT = "tandem_active_alerts_count"
+
 # ── Battery monitoring keys (Phase 1 — from events 81, 53, 36, 37) ────
 TANDEM_SENSOR_KEY_BATTERY_PERCENT = "tandem_battery_percent"
 TANDEM_SENSOR_KEY_BATTERY_VOLTAGE = "tandem_battery_voltage"
@@ -542,6 +547,81 @@ TANDEM_SENSOR_KEY_CHARGING_STATUS = "tandem_charging_status"
 
 # ── Lookup maps for event-derived sensor values ───────────────────────
 CGM_STATUS_MAP: dict[int, str] = {0: "Normal", 1: "High", 2: "Low"}
+
+# Alert and alarm ID → human-readable name maps.
+# Sourced from tconnectsync static_dicts.py (jwoglom/tconnectsync).
+TANDEM_ALERT_MAP: dict[int, str] = {
+    0: "Low Insulin",
+    1: "USB Connection",
+    2: "Low Power",
+    3: "Low Power (Critical)",
+    5: "Auto Off",
+    7: "Power Source",
+    11: "Incomplete Bolus",
+    12: "Incomplete Temp Rate",
+    13: "Incomplete Cartridge Change",
+    17: "Low Insulin (2nd)",
+    19: "Low Transmitter",
+    22: "Sensor Expiring",
+    23: "Sensor Expired",
+    24: "Sensor Failed",
+    25: "Sensor Warmup",
+    26: "Sensor Out Of Range",
+    27: "Sensor High",
+    28: "Sensor Low",
+    29: "CGM Calibration",
+    30: "CGM Cal Due",
+    31: "CGM Cal Error",
+    32: "CGM Trend",
+    33: "CGM Rise",
+    34: "CGM Fall",
+    36: "Sensor Change",
+    38: "Transmitter Low Battery",
+    39: "Transmitter End of Life",
+    40: "Pump Bluetooth Error",
+    42: "CGM High Alert",
+    43: "CGM Low Alert",
+    44: "CGM Urgent Low Alert",
+    45: "CGM Very High Alert",
+    46: "Predicted High Alert",
+    47: "Predicted Low Alert",
+    48: "CGM Unavailable",
+    50: "Feature Activation",
+    52: "Suspend Before Low",
+    53: "Suspend On Low",
+    54: "Resume From Suspend",
+}
+
+TANDEM_ALARM_MAP: dict[int, str] = {
+    0: "Cartridge Alarm",
+    2: "Occlusion",
+    3: "Pump Reset",
+    4: "Motor Error",
+    5: "Infusion Complete",
+    6: "Basal Rate Not Set",
+    7: "Auto Off",
+    8: "Empty Cartridge",
+    9: "Delivery Error",
+    10: "Temperature",
+    11: "Hardware Error",
+    12: "Battery Shutdown",
+    13: "Low Battery",
+    14: "Software Error",
+    15: "Memory Error",
+    16: "Clock Error",
+    17: "Calibration Error",
+    18: "Resume Pump",
+    19: "Cartridge Error",
+    20: "Pressure Error",
+    21: "Altitude",
+    22: "Insulin Expired",
+    23: "Max Daily Insulin",
+    24: "Max Bolus",
+    25: "Cartridge Removed",
+    26: "Priming Error",
+    27: "Plunger Error",
+    28: "Fill Timeout",
+}
 
 # ── Shared icon strings (S1192: avoid duplicating literals 3+ times) ──
 ICON_ALERT_CIRCLE_OUTLINE = "mdi:alert-circle-outline"
@@ -1132,6 +1212,35 @@ TANDEM_SENSORS = (
         device_class=None,
         icon="mdi:battery-alert",
         entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    # ── Alerts & Alarms sensors (Phase 2) ───────────────────────────────
+    SensorEntityDescription(
+        key=TANDEM_SENSOR_KEY_LAST_ALERT,
+        name="Last pump alert",
+        native_unit_of_measurement=None,
+        state_class=None,
+        device_class=None,
+        icon=ICON_ALERT_CIRCLE_OUTLINE,
+        entity_category=None,
+    ),
+    SensorEntityDescription(
+        key=TANDEM_SENSOR_KEY_LAST_ALARM,
+        name="Last pump alarm",
+        native_unit_of_measurement=None,
+        state_class=None,
+        device_class=None,
+        icon="mdi:alarm-light",
+        entity_category=None,
+    ),
+    SensorEntityDescription(
+        key=TANDEM_SENSOR_KEY_ACTIVE_ALERTS_COUNT,
+        name="Active pump alerts",
+        native_unit_of_measurement=None,
+        state_class=None,  # UNAVAILABLE in fallback paths — MEASUREMENT + None causes LTS gaps
+        device_class=None,
+        icon=ICON_ALERT_CIRCLE_OUTLINE,
+        entity_category=None,
+        suggested_display_precision=0,
     ),
     # ── Battery monitoring sensors (Phase 1) ────────────────────────────
     SensorEntityDescription(

--- a/custom_components/carelink/tandem_api.py
+++ b/custom_components/carelink/tandem_api.py
@@ -67,9 +67,14 @@ EVT_CARTRIDGE_FILLED = 33
 EVT_CARBS_ENTERED = 48
 EVT_CANNULA_FILLED = 61
 EVT_TUBING_FILLED = 63
+EVT_ALERT_ACTIVATED = 4
+EVT_ALARM_ACTIVATED = 5
+EVT_MALFUNCTION_ACTIVATED = 6
 EVT_USB_CONNECTED = 36
 EVT_USB_DISCONNECTED = 37
 EVT_SHELF_MODE = 53
+EVT_ALERT_CLEARED = 26
+EVT_ALARM_CLEARED = 28
 EVT_DAILY_BASAL = 81
 EVT_AA_USER_MODE_CHANGE = 229
 EVT_AA_PCM_CHANGE = 230
@@ -307,6 +312,36 @@ def decode_pump_events(raw_b64: str) -> list[dict]:
             evt["battery_current_ma"] = lipo_current
             evt["battery_remaining_mah"] = lipo_rem_cap
             evt["battery_voltage_mv"] = lipo_mv
+
+        elif event_id in (EVT_ALERT_ACTIVATED, EVT_ALARM_ACTIVATED, EVT_MALFUNCTION_ACTIVATED):
+            # payload is always 16 bytes (chunk[10:26], guaranteed by EVENT_LEN guard above).
+            # Struct reads at offsets 0/4/8/12 are fully within bounds.
+            name_map = {
+                EVT_ALERT_ACTIVATED: "AlertActivated",
+                EVT_ALARM_ACTIVATED: "AlarmActivated",
+                EVT_MALFUNCTION_ACTIVATED: "MalfunctionActivated",
+            }
+            evt["event_name"] = name_map[event_id]
+            alert_id = struct.unpack_from(">I", payload, 0)[0]
+            fault_locator = struct.unpack_from(">I", payload, 4)[0]
+            param1 = struct.unpack_from(">I", payload, 8)[0]
+            param2 = struct.unpack_from(">f", payload, 12)[0]
+            evt["alert_id"] = alert_id
+            evt["fault_locator"] = fault_locator
+            evt["param1"] = param1
+            evt["param2"] = round(param2, 3)
+
+        elif event_id == EVT_ALERT_CLEARED:
+            evt["event_name"] = "AlertCleared"
+            alert_id = struct.unpack_from(">I", payload, 0)[0]
+            evt["alert_id"] = alert_id
+
+        elif event_id == EVT_ALARM_CLEARED:
+            # Event 28 clears both AlarmActivated (5) and MalfunctionActivated (6) events.
+            # The pump does not emit a separate MalfunctionCleared event.
+            evt["event_name"] = "AlarmCleared"
+            alert_id = struct.unpack_from(">I", payload, 0)[0]
+            evt["alert_id"] = alert_id
 
         elif event_id == EVT_DAILY_BASAL:
             evt["event_name"] = "DailyBasal"
@@ -722,15 +757,16 @@ class TandemSourceClient:
 
             # Request event types we need for sensor data
             event_ids = (
-                "256,"  # CGM_DATA_GXB (glucose readings)
-                "20,"  # BOLUS_COMPLETED (IOB, delivered, requested)
-                "21,"  # BOLEX_COMPLETED (extended bolus completion)
-                "280,"  # BOLUS_DELIVERY (bolus details)
-                "3,"  # BASAL_RATE_CHANGE (basal rates)
-                "279,"  # BASAL_DELIVERY (commanded rates)
+                "4,"  # ALERT_ACTIVATED
+                "5,"  # ALARM_ACTIVATED
+                "6,"  # MALFUNCTION_ACTIVATED
                 "11,"  # PUMPING_SUSPENDED
                 "12,"  # PUMPING_RESUMED
                 "16,"  # BG_READING_TAKEN (manual BG)
+                "20,"  # BOLUS_COMPLETED (IOB, delivered, requested)
+                "21,"  # BOLEX_COMPLETED (extended bolus completion)
+                "26,"  # ALERT_CLEARED
+                "28,"  # ALARM_CLEARED
                 "33,"  # CARTRIDGE_FILLED
                 "36,"  # USB_CONNECTED (charging)
                 "37,"  # USB_DISCONNECTED
@@ -740,7 +776,10 @@ class TandemSourceClient:
                 "63,"  # TUBING_FILLED
                 "81,"  # DAILY_BASAL (battery %, voltage, daily totals)
                 "229,"  # AA_USER_MODE_CHANGE (sleep/exercise)
-                "230"  # AA_PCM_CHANGE (Control-IQ mode)
+                "230,"  # AA_PCM_CHANGE (Control-IQ mode)
+                "256,"  # CGM_DATA_GXB (glucose readings)
+                "279,"  # BASAL_DELIVERY (commanded rates)
+                "280"  # BOLUS_DELIVERY (bolus details)
             )
 
             url = (

--- a/docs/CHANGE-REGISTER.md
+++ b/docs/CHANGE-REGISTER.md
@@ -4,6 +4,47 @@ Significant changes to this repository, listed in reverse chronological order.
 
 ---
 
+## CR-009 — Alerts & Alarms Sensors (Phase 2)
+**Date:** 2026-03-13
+**Branch:** `feature/alerts-alarms-phase2`
+**PR:** pending
+**Status:** Pre-push gate complete, awaiting PR
+
+### What Changed
+| Area | Change |
+|------|--------|
+| tandem_api.py | Added 5 event constants (EVT_ALERT_ACTIVATED=4, EVT_ALARM_ACTIVATED=5, EVT_MALFUNCTION_ACTIVATED=6, EVT_ALERT_CLEARED=26, EVT_ALARM_CLEARED=28) |
+| tandem_api.py | Added 3 decoder cases; updated get_pump_events() event_ids to include 4, 5, 6, 26, 28 |
+| const.py | Added 3 sensor key constants, TANDEM_ALERT_MAP (~35 entries), TANDEM_ALARM_MAP (~29 entries), 3 SensorEntityDescription entries |
+| __init__.py | Added UNAVAILABLE defaults; updated _parse_pump_events() categorisation; added _parse_alert_alarm_events() |
+| tests | Added TestAlertAlarmDecoders (7 tests) + TestAlertAlarmCoordinator (13 tests); 596 total passing |
+
+### Sensors Added
+| Key | Name | Value |
+|-----|------|-------|
+| tandem_last_alert | Last pump alert | Human-readable alert name (TANDEM_ALERT_MAP) |
+| tandem_last_alarm | Last pump alarm | Human-readable alarm name (TANDEM_ALARM_MAP) |
+| tandem_active_alerts_count | Active pump alerts | Count of uncleared alerts + alarms |
+
+### Review Gate Results
+| Gate | Result |
+|------|--------|
+| silent-failure-hunter | 5 findings; all addressed (comments, error→warning, state_class fix) |
+| code-reviewer | 2 findings; both addressed (state_class=None, malfunction comment) |
+| Logic Review 1 (Opus) | 2 test gaps; both addressed (name assert + malfunction-cleared test) |
+| Sensor Review 3 (Sonnet) | No errors found |
+
+### Quality Gate Results (at branch)
+| Metric | Value | Gate |
+|--------|-------|------|
+| Tests | 596 passed | ✅ |
+| Ruff format | Clean | ✅ |
+| Ruff lint | Clean | ✅ |
+| API drift | None | ✅ |
+| Bandit | Clean | ✅ |
+
+---
+
 ## CR-008 — Display Precision & Fixture Update
 **Date:** 2026-03-13
 **Branch:** `fix/sensor-display-precision`

--- a/docs/ISSUES.md
+++ b/docs/ISSUES.md
@@ -42,7 +42,7 @@ For quick cross-project tasks, see `~/Code/TODO.md`.
 **Type:** Feature / Upstream Sync
 **Priority:** High
 **Created:** 2026-03-13
-**Status:** 🟢 Active — Phase 1 deployed & verified (2026-03-13)
+**Status:** 🟢 Active — Phase 2 complete, awaiting PR
 
 Upstream review of yo-han/Home-Assistant-Carelink (17 commits since fork point `ac6f2a3`) found **no new battery/reservoir sensors upstream**. Battery data IS available in the Tandem Source API via event IDs not previously requested.
 
@@ -59,9 +59,18 @@ Upstream review of yo-han/Home-Assistant-Carelink (17 commits since fork point `
 - ✅ Deployed & verified 2026-03-13. See CR-005, CR-006.
 - ⚠️ Battery voltage (18944 mV) may be raw ADC — investigate with diagnostics capture
 
+**Phase 2 (Alerts & Alarms) — ✅ Code complete, pre-push gate passed:**
+- Branch: `feature/alerts-alarms-phase2`
+- 3 new sensors: last_alert, last_alarm, active_alerts_count
+- TANDEM_ALERT_MAP (~35 entries) + TANDEM_ALARM_MAP (~29 entries) in const.py
+- Active alert/alarm tracking via dict replay (keyed by alert_id, timestamp order)
+- AlarmCleared (28) clears both AlarmActivated and MalfunctionActivated
+- 20 new tests (7 decoder + 13 coordinator), 596 total passing
+- See CR-009
+
 **Remaining phases:**
 1. ~~Phase 1: Battery Monitoring~~ — ✅ Done
-2. Phase 2: Alerts & Alarms — events 4, 5, 6, 26, 28
+2. ~~Phase 2: Alerts & Alarms~~ — ✅ Done (PR pending)
 3. Phase 3: G7 & Libre 2 CGM — events 399, 372, 313
 4. Phase 4: Bolus Calculator — events 64, 65, 66
 5. Phase 5: PLGS & Daily Status — events 140, 90

--- a/docs/reviews/review-findings.md
+++ b/docs/reviews/review-findings.md
@@ -8,6 +8,13 @@ Updated per review. Read this file first in every PR review session (~30 lines).
 |----|----------|--------|----------|-------------|
 | L-5 | Low | OPEN | — | Profile `idp` matching may silently fail |
 | D-1 | Medium | OPEN | — | No binary event fixture |
+| A-1 | Low | FIXED | feature/alerts-alarms-phase2 | payload invariant undocumented — comment added; EVENT_LEN guard makes struct.error impossible in practice |
+| A-2 | High | FIXED | feature/alerts-alarms-phase2 | alarm parse catch used `warning` not `error`; no event counts in log — changed to `error` + added counts |
+| A-3 | Important | FIXED | feature/alerts-alarms-phase2 | active_alerts_count: MEASUREMENT + UNAVAILABLE fallback causes LTS gaps — changed to state_class=None |
+| A-4 | Low | FIXED | feature/alerts-alarms-phase2 | MalfunctionActivated clearing assumption undocumented — comment added |
+| A-5 | Low | FIXED | feature/alerts-alarms-phase2 | `recent` list repeat-activation semantics undocumented — comment added |
+| A-6 | Low | FIXED | feature/alerts-alarms-phase2 | malfunction test asserted `is not UNAVAILABLE` not name — strengthened to `== "Software Error"` |
+| A-7 | Low | FIXED | feature/alerts-alarms-phase2 | missing test: MalfunctionActivated + AlarmCleared → count=0 — test added |
 | D-2 | Low | FIXED | PR #48 | `partNumber` missing from drift check — added to fixture _drift_check |
 | S-2 | Low | FIXED | PR #47 | Inconsistent insulin unit strings — "U" → UNITS constant, "mV" → UnitOfElectricPotential, "kg" → UnitOfMass |
 | S-4 | Low | ACCEPTED | — | Threshold sensors: no HA BLOOD_GLUCOSE device class exists; device_class=None is correct |
@@ -35,15 +42,15 @@ Updated per review. Read this file first in every PR review session (~30 lines).
 | D-4 | OK | pumper_info minimal by design |
 | D-5 | OK | ControlIQ returns 404 |
 
-## File Checksums (updated: 2026-03-13, post PR #48)
+## File Checksums (updated: 2026-03-13, post feature/alerts-alarms-phase2)
 
 Compare before reading files. Skip unchanged files.
 
 ```
-2eb0d3ee __init__.py
-320a4b85 tandem_api.py
-a252e7c1 const.py
-85c251a2 sensor.py
+9458df6c __init__.py
+b3ccfc67 tandem_api.py
+d335e5fe const.py
+f76927b6 sensor.py
 ```
 
 **Status values:** OPEN, ACCEPTED, FIXED, DEFERRED, OK

--- a/tests/test_expanded_data.py
+++ b/tests/test_expanded_data.py
@@ -48,6 +48,12 @@ from custom_components.carelink.const import (
     TANDEM_SENSOR_KEY_BATTERY_VOLTAGE,
     TANDEM_SENSOR_KEY_BATTERY_REMAINING_MAH,
     TANDEM_SENSOR_KEY_CHARGING_STATUS,
+    # Alert & Alarm sensors (Phase 2)
+    TANDEM_SENSOR_KEY_LAST_ALERT,
+    TANDEM_SENSOR_KEY_LAST_ALARM,
+    TANDEM_SENSOR_KEY_ACTIVE_ALERTS_COUNT,
+    TANDEM_ALERT_MAP,
+    TANDEM_ALARM_MAP,
 )
 
 from custom_components.carelink.tandem_api import decode_pump_events
@@ -1085,3 +1091,283 @@ class TestBatterySensorPopulation:
         assert coordinator.data[TANDEM_SENSOR_KEY_BATTERY_VOLTAGE] == 3800
         assert coordinator.data[TANDEM_SENSOR_KEY_BATTERY_REMAINING_MAH] == 250
         assert coordinator.data[TANDEM_SENSOR_KEY_CHARGING_STATUS] == "Charging"
+
+
+# ── Alert / Alarm helpers ─────────────────────────────────────────────────
+
+
+def _make_alert_activated(seq: int, alert_id: int, minutes_ago: int = 0) -> dict:
+    ts = BASE_TS - timedelta(minutes=minutes_ago)
+    return {
+        "event_id": 4,
+        "event_name": "AlertActivated",
+        "seq": seq,
+        "timestamp": ts,
+        "alert_id": alert_id,
+        "fault_locator": 0,
+        "param1": 0,
+        "param2": 0.0,
+    }
+
+
+def _make_alert_cleared(seq: int, alert_id: int, minutes_ago: int = 0) -> dict:
+    ts = BASE_TS - timedelta(minutes=minutes_ago)
+    return {
+        "event_id": 26,
+        "event_name": "AlertCleared",
+        "seq": seq,
+        "timestamp": ts,
+        "alert_id": alert_id,
+    }
+
+
+def _make_alarm_activated(seq: int, alarm_id: int, minutes_ago: int = 0) -> dict:
+    ts = BASE_TS - timedelta(minutes=minutes_ago)
+    return {
+        "event_id": 5,
+        "event_name": "AlarmActivated",
+        "seq": seq,
+        "timestamp": ts,
+        "alert_id": alarm_id,
+        "fault_locator": 0,
+        "param1": 0,
+        "param2": 0.0,
+    }
+
+
+def _make_alarm_cleared(seq: int, alarm_id: int, minutes_ago: int = 0) -> dict:
+    ts = BASE_TS - timedelta(minutes=minutes_ago)
+    return {
+        "event_id": 28,
+        "event_name": "AlarmCleared",
+        "seq": seq,
+        "timestamp": ts,
+        "alert_id": alarm_id,
+    }
+
+
+def _make_malfunction_activated(seq: int, malfunction_id: int, minutes_ago: int = 0) -> dict:
+    ts = BASE_TS - timedelta(minutes=minutes_ago)
+    return {
+        "event_id": 6,
+        "event_name": "MalfunctionActivated",
+        "seq": seq,
+        "timestamp": ts,
+        "alert_id": malfunction_id,
+        "fault_locator": 1,
+        "param1": 0,
+        "param2": 0.0,
+    }
+
+
+# ── Decoder tests: events 4, 5, 6, 26, 28 ────────────────────────────────
+
+
+class TestAlertAlarmDecoders:
+    """Test binary decoding of alert and alarm event types."""
+
+    def _decode_single(self, event_id: int, payload: bytes, seq: int = 1) -> dict:
+        raw = _build_binary_event(event_id, seq, 500000000, payload)
+        b64 = base64.b64encode(raw).decode()
+        events = decode_pump_events(b64)
+        assert len(events) == 1
+        return events[0]
+
+    def _alert_payload(self, alert_id: int, fault: int = 0, p1: int = 0, p2: float = 0.0) -> bytes:
+        return struct.pack(">I", alert_id) + struct.pack(">I", fault) + struct.pack(">I", p1) + struct.pack(">f", p2)
+
+    def test_decode_alert_activated(self):
+        """Event 4 (AlertActivated) decodes alert_id and params."""
+        payload = self._alert_payload(alert_id=0, fault=5, p1=10, p2=1.5)
+        evt = self._decode_single(4, payload)
+        assert evt["event_name"] == "AlertActivated"
+        assert evt["alert_id"] == 0
+        assert evt["fault_locator"] == 5
+        assert evt["param1"] == 10
+        assert abs(evt["param2"] - 1.5) < 0.001
+
+    def test_decode_alarm_activated(self):
+        """Event 5 (AlarmActivated) decodes alarm_id."""
+        payload = self._alert_payload(alert_id=2)
+        evt = self._decode_single(5, payload)
+        assert evt["event_name"] == "AlarmActivated"
+        assert evt["alert_id"] == 2
+
+    def test_decode_malfunction_activated(self):
+        """Event 6 (MalfunctionActivated) decodes malfunction_id."""
+        payload = self._alert_payload(alert_id=14, fault=99)
+        evt = self._decode_single(6, payload)
+        assert evt["event_name"] == "MalfunctionActivated"
+        assert evt["alert_id"] == 14
+        assert evt["fault_locator"] == 99
+
+    def test_decode_alert_cleared(self):
+        """Event 26 (AlertCleared) decodes only alert_id."""
+        payload = struct.pack(">I", 0) + bytes(12)
+        evt = self._decode_single(26, payload)
+        assert evt["event_name"] == "AlertCleared"
+        assert evt["alert_id"] == 0
+
+    def test_decode_alarm_cleared(self):
+        """Event 28 (AlarmCleared) decodes only alarm_id."""
+        payload = struct.pack(">I", 8) + bytes(12)
+        evt = self._decode_single(28, payload)
+        assert evt["event_name"] == "AlarmCleared"
+        assert evt["alert_id"] == 8
+
+    def test_decode_alert_activated_known_id(self):
+        """AlertActivated with a known ID resolves to name in TANDEM_ALERT_MAP."""
+        payload = self._alert_payload(alert_id=0)
+        evt = self._decode_single(4, payload)
+        assert TANDEM_ALERT_MAP.get(evt["alert_id"]) == "Low Insulin"
+
+    def test_decode_alarm_activated_known_id(self):
+        """AlarmActivated with a known ID resolves to name in TANDEM_ALARM_MAP."""
+        payload = self._alert_payload(alert_id=2)
+        evt = self._decode_single(5, payload)
+        assert TANDEM_ALARM_MAP.get(evt["alert_id"]) == "Occlusion"
+
+
+# ── Coordinator tests: alert/alarm sensor population ─────────────────────
+
+
+class TestAlertAlarmCoordinator:
+    """Test coordinator alert/alarm sensor population from events 4, 5, 6, 26, 28."""
+
+    async def test_no_events_all_unavailable(self, hass: HomeAssistant):
+        """No alert/alarm events → sensors are UNAVAILABLE."""
+        data = _make_pump_events_data([_make_cgm_event(1, 100)])
+        coordinator = await _setup_coordinator(hass, data)
+        assert coordinator.data[TANDEM_SENSOR_KEY_LAST_ALERT] is UNAVAILABLE
+        assert coordinator.data[TANDEM_SENSOR_KEY_LAST_ALARM] is UNAVAILABLE
+        assert coordinator.data[TANDEM_SENSOR_KEY_ACTIVE_ALERTS_COUNT] == 0
+
+    async def test_single_alert_activated(self, hass: HomeAssistant):
+        """Single AlertActivated → last_alert = known name, count = 1."""
+        events = [
+            _make_cgm_event(1, 100),
+            _make_alert_activated(2, alert_id=0),  # "Low Insulin"
+        ]
+        coordinator = await _setup_coordinator(hass, _make_pump_events_data(events))
+        assert coordinator.data[TANDEM_SENSOR_KEY_LAST_ALERT] == "Low Insulin"
+        assert coordinator.data[TANDEM_SENSOR_KEY_ACTIVE_ALERTS_COUNT] == 1
+
+    async def test_alert_activated_unknown_id(self, hass: HomeAssistant):
+        """AlertActivated with unknown ID → fallback 'Alert <id>'."""
+        events = [
+            _make_cgm_event(1, 100),
+            _make_alert_activated(2, alert_id=999),
+        ]
+        coordinator = await _setup_coordinator(hass, _make_pump_events_data(events))
+        assert coordinator.data[TANDEM_SENSOR_KEY_LAST_ALERT] == "Alert 999"
+
+    async def test_alert_cleared_reduces_count(self, hass: HomeAssistant):
+        """AlertActivated then AlertCleared → count = 0, last_alert still set."""
+        events = [
+            _make_cgm_event(1, 100),
+            _make_alert_activated(2, alert_id=0, minutes_ago=10),
+            _make_alert_cleared(3, alert_id=0, minutes_ago=5),
+        ]
+        coordinator = await _setup_coordinator(hass, _make_pump_events_data(events))
+        assert coordinator.data[TANDEM_SENSOR_KEY_LAST_ALERT] == "Low Insulin"
+        assert coordinator.data[TANDEM_SENSOR_KEY_ACTIVE_ALERTS_COUNT] == 0
+        # Attributes reflect cleared=True
+        attrs = coordinator.data.get(f"{TANDEM_SENSOR_KEY_LAST_ALERT}_attributes", {})
+        assert attrs["cleared"] is True
+
+    async def test_alert_attributes_structure(self, hass: HomeAssistant):
+        """last_alert attributes contain expected keys."""
+        events = [
+            _make_cgm_event(1, 100),
+            _make_alert_activated(2, alert_id=0),
+        ]
+        coordinator = await _setup_coordinator(hass, _make_pump_events_data(events))
+        attrs = coordinator.data.get(f"{TANDEM_SENSOR_KEY_LAST_ALERT}_attributes", {})
+        assert "alert_id" in attrs
+        assert "cleared" in attrs
+        assert "timestamp" in attrs
+        assert "recent" in attrs
+        assert isinstance(attrs["recent"], list)
+
+    async def test_recent_list_capped_at_10(self, hass: HomeAssistant):
+        """recent list in attributes is capped at 10 entries."""
+        events = [_make_cgm_event(1, 100)] + [
+            _make_alert_activated(i + 2, alert_id=i % 5, minutes_ago=100 - i) for i in range(15)
+        ]
+        coordinator = await _setup_coordinator(hass, _make_pump_events_data(events))
+        attrs = coordinator.data.get(f"{TANDEM_SENSOR_KEY_LAST_ALERT}_attributes", {})
+        assert len(attrs["recent"]) <= 10
+
+    async def test_single_alarm_activated(self, hass: HomeAssistant):
+        """Single AlarmActivated → last_alarm = known name."""
+        events = [
+            _make_cgm_event(1, 100),
+            _make_alarm_activated(2, alarm_id=2),  # "Occlusion"
+        ]
+        coordinator = await _setup_coordinator(hass, _make_pump_events_data(events))
+        assert coordinator.data[TANDEM_SENSOR_KEY_LAST_ALARM] == "Occlusion"
+        assert coordinator.data[TANDEM_SENSOR_KEY_ACTIVE_ALERTS_COUNT] == 1
+
+    async def test_malfunction_activates_alarm_sensor(self, hass: HomeAssistant):
+        """MalfunctionActivated (event 6) populates last_alarm sensor with resolved name."""
+        events = [
+            _make_cgm_event(1, 100),
+            _make_malfunction_activated(2, malfunction_id=14),  # 14 = "Software Error"
+        ]
+        coordinator = await _setup_coordinator(hass, _make_pump_events_data(events))
+        assert coordinator.data[TANDEM_SENSOR_KEY_LAST_ALARM] == "Software Error"
+        assert coordinator.data[TANDEM_SENSOR_KEY_ACTIVE_ALERTS_COUNT] == 1
+
+    async def test_malfunction_cleared_by_alarm_cleared(self, hass: HomeAssistant):
+        """MalfunctionActivated then AlarmCleared (same ID) → count = 0."""
+        events = [
+            _make_cgm_event(1, 100),
+            _make_malfunction_activated(2, malfunction_id=14, minutes_ago=10),
+            _make_alarm_cleared(3, alarm_id=14, minutes_ago=5),
+        ]
+        coordinator = await _setup_coordinator(hass, _make_pump_events_data(events))
+        assert coordinator.data[TANDEM_SENSOR_KEY_LAST_ALARM] == "Software Error"
+        assert coordinator.data[TANDEM_SENSOR_KEY_ACTIVE_ALERTS_COUNT] == 0
+
+    async def test_alarm_cleared_reduces_count(self, hass: HomeAssistant):
+        """AlarmActivated then AlarmCleared → count = 0."""
+        events = [
+            _make_cgm_event(1, 100),
+            _make_alarm_activated(2, alarm_id=2, minutes_ago=10),
+            _make_alarm_cleared(3, alarm_id=2, minutes_ago=5),
+        ]
+        coordinator = await _setup_coordinator(hass, _make_pump_events_data(events))
+        assert coordinator.data[TANDEM_SENSOR_KEY_LAST_ALARM] == "Occlusion"
+        assert coordinator.data[TANDEM_SENSOR_KEY_ACTIVE_ALERTS_COUNT] == 0
+
+    async def test_mixed_alerts_and_alarms_count(self, hass: HomeAssistant):
+        """Two active alerts + one active alarm → count = 3."""
+        events = [
+            _make_cgm_event(1, 100),
+            _make_alert_activated(2, alert_id=0),  # Low Insulin — active
+            _make_alert_activated(3, alert_id=2),  # Low Power — active
+            _make_alarm_activated(4, alarm_id=2),  # Occlusion — active
+        ]
+        coordinator = await _setup_coordinator(hass, _make_pump_events_data(events))
+        assert coordinator.data[TANDEM_SENSOR_KEY_ACTIVE_ALERTS_COUNT] == 3
+
+    async def test_partial_clears_reduce_count(self, hass: HomeAssistant):
+        """Two alerts activated, one cleared → count = 1."""
+        events = [
+            _make_cgm_event(1, 100),
+            _make_alert_activated(2, alert_id=0, minutes_ago=20),
+            _make_alert_activated(3, alert_id=2, minutes_ago=15),
+            _make_alert_cleared(4, alert_id=0, minutes_ago=5),
+        ]
+        coordinator = await _setup_coordinator(hass, _make_pump_events_data(events))
+        assert coordinator.data[TANDEM_SENSOR_KEY_ACTIVE_ALERTS_COUNT] == 1
+
+    async def test_no_alerts_alarm_only(self, hass: HomeAssistant):
+        """No alert events but alarm present → last_alert UNAVAILABLE, last_alarm set."""
+        events = [
+            _make_cgm_event(1, 100),
+            _make_alarm_activated(2, alarm_id=8),  # "Empty Cartridge"
+        ]
+        coordinator = await _setup_coordinator(hass, _make_pump_events_data(events))
+        assert coordinator.data[TANDEM_SENSOR_KEY_LAST_ALERT] is UNAVAILABLE
+        assert coordinator.data[TANDEM_SENSOR_KEY_LAST_ALARM] == "Empty Cartridge"


### PR DESCRIPTION
## Summary
- Add 3 new Tandem sensors sourced from pump events 4, 5, 6, 26, 28: `tandem_last_alert`, `tandem_last_alarm`, `tandem_active_alerts_count`
- Add `TANDEM_ALERT_MAP` (~35 entries) and `TANDEM_ALARM_MAP` (~29 entries) in `const.py` (sourced from tconnectsync)
- Active tracking replays events in timestamp order using a dict keyed on `alert_id`; `AlarmCleared` (28) clears both alarms and malfunctions
- Attributes include `alert_id`, `cleared` state, `timestamp`, and `recent` (last 10 activations)

## AI Review Gate Results
| Gate | Findings | Status |
|------|----------|--------|
| silent-failure-hunter | A-1 through A-5 | All addressed |
| code-reviewer | A-3 (state_class), A-4 (comment) | All addressed |
| Logic Review 1 — Opus | A-6, A-7 (test gaps) | Both addressed |
| Sensor Review 3 — Sonnet | None | Clean |

Key fixes from reviews: payload invariant documented, `_LOGGER.warning` → `_LOGGER.error` with event counts, `state_class=None` on active_alerts_count (avoids MEASUREMENT+UNAVAILABLE LTS gaps), malfunction-clearing assumption commented, test strengthened to assert name string, new test for MalfunctionActivated + AlarmCleared flow.

## Post-Deploy Actions
- None required — new sensors appear automatically after HA restart

## Test Plan
- [ ] HA restart with new code — no errors in log
- [ ] `tandem_last_alert`, `tandem_last_alarm`, `tandem_active_alerts_count` sensors visible in HA
- [ ] Sensor attributes include `alert_id`, `cleared`, `timestamp`, `recent`
- [ ] If pump has recent alert history: verify name matches expected (e.g. "Low Insulin", "Occlusion")
- [ ] 596 tests passing (CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)