### PR TITLE
fix(tandem): bolus calc attrs as extra_state_attributes, not sensor entity

### DIFF
--- a/custom_components/carelink/const.py
+++ b/custom_components/carelink/const.py
@@ -547,7 +547,7 @@ TANDEM_SENSOR_KEY_LAST_BOLUS_BG = "tandem_last_bolus_bg"
 TANDEM_SENSOR_KEY_LAST_BOLUS_CARBS = "tandem_last_bolus_carbs_entered"
 TANDEM_SENSOR_KEY_LAST_BOLUS_CORRECTION = "tandem_last_bolus_correction"
 TANDEM_SENSOR_KEY_LAST_BOLUS_FOOD = "tandem_last_bolus_food_portion"
-TANDEM_SENSOR_KEY_BOLUS_CALC_ATTRS = "tandem_bolus_calculator_attributes"
+TANDEM_SENSOR_KEY_BOLUS_CALC_ATTRS = "tandem_last_bolus_bg_attributes"
 
 # ── Battery monitoring keys (Phase 1 — from events 81, 53, 36, 37) ────
 TANDEM_SENSOR_KEY_BATTERY_PERCENT = "tandem_battery_percent"
@@ -1341,15 +1341,6 @@ TANDEM_SENSORS = (
         icon="mdi:needle",
         entity_category=None,
         suggested_display_precision=2,
-    ),
-    SensorEntityDescription(
-        key=TANDEM_SENSOR_KEY_BOLUS_CALC_ATTRS,
-        name="Bolus calculator details",
-        native_unit_of_measurement=None,
-        state_class=None,
-        device_class=None,
-        icon="mdi:calculator",
-        entity_category=EntityCategory.DIAGNOSTIC,
     ),
 )
 


### PR DESCRIPTION
## Summary
- Removed `TANDEM_SENSOR_KEY_BOLUS_CALC_ATTRS` SensorEntityDescription from `TANDEM_SENSORS` — it was passing a dict as `native_value`, which HA sensors don't support (scalars only)
- Changed the data key to `tandem_last_bolus_bg_attributes` to follow the existing `{sensor_key}_attributes` convention used by `sensor.py`'s `extra_state_attributes` property
- Bolus calculator details (bolus_id, total_bolus, iob, carb_ratio, target_bg, isf, correction flags, timestamp) now surface as attributes on the BG sensor entity instead of as a separate broken sensor

## Test Plan
- [x] 627 tests passing (no test changes needed — tests use the constant, not the string)
- [ ] After deploy: verify `sensor.tandem_last_bolus_bg` shows attributes (bolus_id, total_bolus, etc.)
- [ ] Verify the old `sensor.tandem_bolus_calculator_attributes` entity no longer appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)