### PR TITLE
docs: Phase 4 completion updates, CR-012, review-findings fixes

### DIFF
--- a/docs/CHANGE-REGISTER.md
+++ b/docs/CHANGE-REGISTER.md
@@ -4,11 +4,28 @@ Significant changes to this repository, listed in reverse chronological order.
 
 ---
 
+## CR-012 — Bolus Calculator Attributes Bugfix
+**Date:** 2026-03-13
+**Branch:** `bugfix/bolus-calc-attrs-not-sensor`
+**PR:** [#53](https://github.com/jnctech/ha-tandem-pump/pull/53)
+**Status:** Merged & deployed
+
+### What Changed
+| Area | Change |
+|------|--------|
+| const.py | Removed `TANDEM_SENSOR_KEY_BOLUS_CALC_ATTRS` SensorEntityDescription — dict values are not valid HA sensor states |
+| const.py | Changed constant value to `"tandem_last_bolus_bg_attributes"` so bolus calc details surface as `extra_state_attributes` on `last_bolus_bg` sensor via the existing `_attributes` convention in `sensor.py` |
+
+### Why
+Code review (post-merge on PR #52) identified that the `bolus_calculator_attributes` sensor was passing a dict as `native_value`. HA sensors require scalar values. The existing codebase pattern for attribute dicts (e.g., `LAST_BOLUS_ATTRS`, `LAST_MEAL_BOLUS_ATTRS`) stores them as coordinator data keys with `_attributes` suffix but does NOT register them as SensorEntityDescriptions. Applied the same pattern.
+
+---
+
 ## CR-011 — Bolus Calculator Sensors (Phase 4)
 **Date:** 2026-03-13
 **Branch:** `feature/bolus-calculator-phase4`
-**PR:** pending
-**Status:** Pre-push gate in progress
+**PR:** [#52](https://github.com/jnctech/ha-tandem-pump/pull/52)
+**Status:** Merged & deployed (bugfix in CR-012)
 
 ### What Changed
 | Area | Change |
@@ -16,19 +33,18 @@ Significant changes to this repository, listed in reverse chronological order.
 | tandem_api.py | Added 3 event constants (EVT_BOLUS_REQUESTED_MSG1=64, MSG2=65, MSG3=66) |
 | tandem_api.py | Added 3 decoder cases for bolus calculator messages (BG, carbs, IOB, ISF, food/correction split) |
 | tandem_api.py | Updated get_pump_events() event_ids to include 64, 65, 66 |
-| const.py | Added 5 sensor key constants and SensorEntityDescriptions |
+| const.py | Added 5 sensor key constants and 4 SensorEntityDescriptions (5th removed in CR-012) |
 | __init__.py | Added 3-way join by BolusID across msg1/msg2/msg3 events |
-| __init__.py | Populate 4 primary sensors + 1 diagnostic attributes sensor from latest complete bolus calc record |
-| tests | Added TestBolusCalcDecoder (6 tests) + TestBolusCalcCoordinator (6 tests); 625 total passing |
+| __init__.py | Populate 4 primary sensors + attributes dict from latest complete bolus calc record |
+| tests | Added TestBolusCalcDecoder (6 tests) + TestBolusCalcCoordinator (8 tests); 627 total passing |
 
 ### Sensors Added
 | Key | Name | Value |
 |-----|------|-------|
-| tandem_last_bolus_bg | Last bolus BG | mg/dL at time of bolus request |
+| tandem_last_bolus_bg | Last bolus BG | mg/dL at time of bolus request (+ bolus calc details as extra_state_attributes) |
 | tandem_last_bolus_carbs_entered | Last bolus carbs entered | grams entered into calculator |
 | tandem_last_bolus_correction | Last bolus correction | units (correction portion) |
 | tandem_last_bolus_food_portion | Last bolus food portion | units (food portion) |
-| tandem_bolus_calculator_attributes | Bolus calculator details | Full joined record (IOB, ISF, target BG, carb ratio, etc.) |
 
 ### Review Gate Results
 | Gate | Result |
@@ -37,12 +53,12 @@ Significant changes to this repository, listed in reverse chronological order.
 | API Drift Review 2 (Opus) | No drift (binary events not in JSON fixture) |
 | Sensor Review 3 (Sonnet) | All correct |
 | silent-failure-hunter | No new findings (pre-existing C-4 noted) |
-| code-reviewer | No issues |
+| code-reviewer | 1 critical finding — dict-as-sensor (fixed in CR-012) |
 
 ### Quality Gate Results (at branch)
 | Metric | Value | Gate |
 |--------|-------|------|
-| Tests | 625 passed | ✅ |
+| Tests | 627 passed | ✅ |
 | Ruff format | Clean | ✅ |
 | Ruff lint | Clean | ✅ |
 | API drift | None | ✅ |

--- a/docs/ISSUES.md
+++ b/docs/ISSUES.md
@@ -7,7 +7,7 @@ For quick cross-project tasks, see `~/Code/TODO.md`.
 
 ## Current Priorities
 
-1. **ISS-011 Phase 4+** — Bolus Calculator, PLGS, ERI
+1. **ISS-011 Phase 5+** — PLGS & Daily Status, ERI
 2. **ISS-010** — ADRs + templates done; tooling + ADR-007/008 remaining
 3. **ISS-005** — tandem_api.py coverage gap
 4. Remaining baseline findings (D-1, L-5, S-4)
@@ -41,7 +41,7 @@ For quick cross-project tasks, see `~/Code/TODO.md`.
 **Type:** Feature / Upstream Sync
 **Priority:** High
 **Created:** 2026-03-13
-**Status:** 🟢 Active — Phase 4 in progress (PR pending)
+**Status:** 🟢 Active — Phase 4 deployed, Phase 5 next
 
 Upstream review of yo-han/Home-Assistant-Carelink (17 commits since fork point `ac6f2a3`) found **no new battery/reservoir sensors upstream**. Battery data IS available in the Tandem Source API via event IDs not previously requested.
 
@@ -74,18 +74,20 @@ Upstream review of yo-han/Home-Assistant-Carelink (17 commits since fork point `
 - 19 new tests (11 decoder + 8 coordinator), 613 total passing
 - See CR-010
 
-**Phase 4 (Bolus Calculator) — ✅ Code complete, PR pending:**
-- Branch: `feature/bolus-calculator-phase4`
-- 5 new sensors: last_bolus_bg, last_bolus_carbs_entered, last_bolus_correction, last_bolus_food_portion, bolus_calculator_attributes
+**Phase 4 (Bolus Calculator) — ✅ Deployed & verified:**
+- PR #52 (implementation) + PR #53 (bugfix: remove dict-as-sensor, use _attributes pattern)
+- 4 new sensors: last_bolus_bg, last_bolus_carbs_entered, last_bolus_correction, last_bolus_food_portion
+- Bolus calculator details surfaced as extra_state_attributes on last_bolus_bg (not a standalone sensor)
 - 3-way join by BolusID across events 64/65/66
-- 12 new tests (6 decoder + 6 coordinator), 625 total passing
-- See CR-011
+- 14 new tests (6 decoder + 8 coordinator), 627 total passing
+- Sensors show "unknown" until bolus calculator wizard is used (quick boluses are event 17, not 64/65/66)
+- See CR-011, CR-012
 
 **Remaining phases:**
 1. ~~Phase 1: Battery Monitoring~~ — ✅ Done
 2. ~~Phase 2: Alerts & Alarms~~ — ✅ Done
 3. ~~Phase 3: G7 & Libre 2 CGM~~ — ✅ Merged (PR #50, #51)
-4. ~~Phase 4: Bolus Calculator~~ — ✅ Code complete (PR pending)
+4. ~~Phase 4: Bolus Calculator~~ — ✅ Deployed & verified (PR #52, #53)
 5. Phase 5: PLGS & Daily Status — events 140, 90
 6. Phase 6: Estimated Remaining Insulin — computed from existing events
 

--- a/docs/reviews/review-findings.md
+++ b/docs/reviews/review-findings.md
@@ -7,6 +7,8 @@ Updated per review. Read this file first in every PR review session (~30 lines).
 | ID | Severity | Status | Fixed In | Description |
 |----|----------|--------|----------|-------------|
 | L-5 | Low | OPEN | — | Profile `idp` matching may silently fail |
+| B-1 | Low | OPEN | — | Missing test: msg1+msg3 without msg2 — join works but msg2 fields are None in attrs |
+| B-2 | Low | OPEN | — | carb_ratio 1000x multiplier from tconnectsync spec — cannot validate without real capture |
 | D-1 | Medium | OPEN | — | No binary event fixture |
 | C-1 | High | FIXED | feature/cgm-g7-libre2-phase3 | Magic event IDs in coordinator — replaced ALL with EVT_* constants from tandem_api |
 | C-2 | High | FIXED | feature/cgm-g7-libre2-phase3 | Daily status `except Exception` + `warning` — narrowed to `(KeyError, TypeError, IndexError)` + `error` + event count |
@@ -47,17 +49,14 @@ Updated per review. Read this file first in every PR review session (~30 lines).
 | D-4 | OK | pumper_info minimal by design |
 | D-5 | OK | ControlIQ returns 404 |
 
-| B-1 | Low | OPEN | — | Missing test: msg1+msg3 without msg2 — join works but msg2 fields are None in attrs |
-| B-2 | Low | OPEN | — | carb_ratio 1000x multiplier from tconnectsync spec — cannot validate without real capture |
-
-## File Checksums (updated: 2026-03-13, post feature/bolus-calculator-phase4)
+## File Checksums (updated: 2026-03-13, post PR #53 bugfix/bolus-calc-attrs-not-sensor)
 
 Compare before reading files. Skip unchanged files.
 
 ```
-66998ade __init__.py
+ec093426 __init__.py
 7f1a5d40 tandem_api.py
-86911888 const.py
+022f7643 const.py
 d0a63142 sensor.py
 ```
 


### PR DESCRIPTION
## Summary
- Updated ISSUES.md: Phase 4 → "Deployed & verified", priorities reordered (Phase 5 next)
- Added CR-012 to CHANGE-REGISTER.md for PR #53 bugfix (dict-as-sensor removal)
- Updated CR-011 with correct PR number (#52), merged status, 4 sensors (not 5)
- Fixed review-findings.md: B-1/B-2 moved from Accepted/Closed table to Open Findings where they belong
- Updated file checksums in review-findings.md post-PR #53
- Deleted stale branches: `feature/bolus-calculator-phase4`, `bugfix/bolus-calc-attrs-not-sensor`

## Test plan
- [ ] Docs-only change — no code, no tests needed
- [ ] Verify CHANGE-REGISTER.md renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)