### PR TITLE
release: v1.6.0 — HACS compliance

### DIFF
--- a/custom_components/carelink/__init__.py
+++ b/custom_components/carelink/__init__.py
@@ -16,6 +16,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.util.dt import DEFAULT_TIME_ZONE
 from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers.update_coordinator import (
     DataUpdateCoordinator,
     UpdateFailed,
@@ -347,18 +348,21 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 async def _async_setup_carelink_entry(hass: HomeAssistant, entry: ConfigEntry, config: dict) -> bool:
     """Set up a Medtronic Carelink config entry."""
     # Migrate logindata from old location if needed
-    _migrate_legacy_logindata(hass.config.path(), entry.entry_id)
+    await hass.async_add_executor_job(_migrate_legacy_logindata, hass.config.path(), entry.entry_id)
 
-    carelink_client = CarelinkClient(
-        config["cl_refresh_token"],
-        config["cl_token"],
-        config["cl_client_id"],
-        config["cl_client_secret"],
-        config["cl_mag_identifier"],
-        config["patientId"],
-        config_path=hass.config.path(),
-        entry_id=entry.entry_id,
-    )
+    try:
+        carelink_client = CarelinkClient(
+            config["cl_refresh_token"],
+            config["cl_token"],
+            config["cl_client_id"],
+            config["cl_client_secret"],
+            config["cl_mag_identifier"],
+            config["patientId"],
+            config_path=hass.config.path(),
+            entry_id=entry.entry_id,
+        )
+    except Exception as err:
+        raise ConfigEntryNotReady(f"Failed to initialise Carelink client: {err}") from err
 
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {
         CLIENT: carelink_client,
@@ -574,11 +578,14 @@ async def _async_setup_tandem_entry(hass: HomeAssistant, entry: ConfigEntry, con
     """Set up a Tandem t:slim Source config entry."""
     _LOGGER.info("Setting up Tandem entry: %s", entry.entry_id)
 
-    tandem_client = TandemSourceClient(
-        email=config["tandem_email"],
-        password=config["tandem_password"],
-        region=config.get("tandem_region", "EU"),
-    )
+    try:
+        tandem_client = TandemSourceClient(
+            email=config["tandem_email"],
+            password=config["tandem_password"],
+            region=config.get("tandem_region", "EU"),
+        )
+    except Exception as err:
+        raise ConfigEntryNotReady(f"Failed to initialise Tandem client: {err}") from err
 
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {
         TANDEM_CLIENT: tandem_client,
@@ -1067,7 +1074,7 @@ class TandemCoordinator(DataUpdateCoordinator):
         try:
             await self.client.login()
         except TandemAuthError as err:
-            raise UpdateFailed(f"Tandem authentication failed: {err}") from err
+            raise ConfigEntryAuthFailed(f"Tandem authentication failed: {err}") from err
         except Exception as err:
             _LOGGER.debug("Unexpected error during Tandem login: %s", err, exc_info=True)
             raise UpdateFailed(f"Tandem login error: {err}") from err

--- a/custom_components/carelink/__init__.py
+++ b/custom_components/carelink/__init__.py
@@ -675,7 +675,14 @@ class CarelinkCoordinator(DataUpdateCoordinator):
         client_timezone = DEFAULT_TIME_ZONE
 
         try:
-            await self.client.login()
+            logged_in = await self.client.login()
+        except Exception as err:
+            raise UpdateFailed(f"Carelink login error: {err}") from err
+
+        if not logged_in:
+            raise ConfigEntryAuthFailed("Carelink authentication failed — credentials may have expired")
+
+        try:
             recent_data = await self.client.get_recent_data()
         except Exception as err:
             raise UpdateFailed(f"Carelink data fetch failed: {err}") from err

--- a/custom_components/carelink/config_flow.py
+++ b/custom_components/carelink/config_flow.py
@@ -202,6 +202,13 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 _LOGGER.exception("Unexpected exception")
                 errors["base"] = "unknown"
             else:
+                # Use patient ID as unique ID to prevent duplicate entries
+                patient_id = user_input.get("patientId", "")
+                if patient_id:
+                    await self.async_set_unique_id(f"carelink_{patient_id}")
+                    self._abort_if_unique_id_configured()
+                else:
+                    _LOGGER.debug("No patientId provided — duplicate entry detection disabled")
                 return self.async_create_entry(title=info["title"], data=user_input)
 
         return self.async_show_form(
@@ -267,10 +274,60 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 _LOGGER.exception("Unexpected exception")
                 errors["base"] = "unknown"
             else:
+                # Use email + region as unique ID to prevent duplicate entries
+                email = user_input.get("tandem_email", "").strip().lower()
+                region = user_input.get("tandem_region", "EU")
+                await self.async_set_unique_id(f"tandem_{email}_{region}")
+                self._abort_if_unique_id_configured()
                 return self.async_create_entry(title=info["title"], data=user_input)
 
         return self.async_show_form(
             step_id="tandem", data_schema=self._get_tandem_schema(user_input, include_auth=True), errors=errors
+        )
+
+    # ── Reauth (triggered by ConfigEntryAuthFailed) ────────────────────
+
+    async def async_step_reauth(self, entry_data: dict[str, Any]) -> FlowResult:
+        """Handle reauth triggered by ConfigEntryAuthFailed."""
+        return await self.async_step_reauth_confirm()
+
+    async def async_step_reauth_confirm(self, user_input: dict[str, Any] | None = None) -> FlowResult:
+        """Handle reauth credential entry."""
+        errors = {}
+        entry = self.hass.config_entries.async_get_entry(self.context["entry_id"])
+        if entry is None:
+            return self.async_abort(reason="unknown")
+        platform = entry.data.get(PLATFORM_TYPE, PLATFORM_CARELINK)
+
+        if user_input is not None:
+            full_config = {**entry.data, **user_input}
+
+            try:
+                if platform == PLATFORM_TANDEM:
+                    await validate_tandem_input(full_config)
+                else:
+                    await validate_carelink_input(self.hass, full_config)
+            except CannotConnect:
+                errors["base"] = "cannot_connect"
+            except InvalidAuth:
+                errors["base"] = "invalid_auth"
+            except Exception:  # pylint: disable=broad-except
+                _LOGGER.exception("Unexpected exception during reauth")
+                errors["base"] = "unknown"
+            else:
+                self.hass.config_entries.async_update_entry(entry, data=full_config)
+                await self.hass.config_entries.async_reload(entry.entry_id)
+                return self.async_abort(reason="reauth_successful")
+
+        if platform == PLATFORM_TANDEM:
+            schema = self._get_tandem_schema(dict(entry.data), include_auth=True)
+        else:
+            schema = self._get_carelink_schema(dict(entry.data), include_auth=True)
+
+        return self.async_show_form(
+            step_id="reauth_confirm",
+            data_schema=schema,
+            errors=errors,
         )
 
     # ── Reconfiguration ──────────────────────────────────────────────────

--- a/custom_components/carelink/helpers.py
+++ b/custom_components/carelink/helpers.py
@@ -81,7 +81,7 @@ class PumpEntityMixin:
     @property
     def unique_id(self) -> str:
         """Return a unique ID for this sensor."""
-        return f"{DOMAIN.lower()}_{self.sensor_description.key}"
+        return f"{DOMAIN}_{self.coordinator.entry_id}_{self.sensor_description.key}"
 
     @property
     def icon(self) -> str | None:

--- a/custom_components/carelink/manifest.json
+++ b/custom_components/carelink/manifest.json
@@ -9,8 +9,8 @@
   "homekit": {},
   "integration_type": "hub",
   "iot_class": "cloud_polling",
-  "loggers": ["httpx"],
   "issue_tracker": "https://github.com/jnctech/ha-tandem-pump/issues",
+  "loggers": ["httpx"],
   "requirements": ["aiofiles==24.1.0", "certifi==2024.12.14", "httpx==0.28.1"],
   "version": "1.5.0",
   "zeroconf": []

--- a/custom_components/carelink/manifest.json
+++ b/custom_components/carelink/manifest.json
@@ -12,6 +12,6 @@
   "issue_tracker": "https://github.com/jnctech/ha-tandem-pump/issues",
   "loggers": ["httpx"],
   "requirements": ["aiofiles==24.1.0", "certifi==2024.12.14", "httpx==0.28.1"],
-  "version": "1.5.0",
+  "version": "1.6.0",
   "zeroconf": []
 }

--- a/custom_components/carelink/manifest.json
+++ b/custom_components/carelink/manifest.json
@@ -7,9 +7,11 @@
   "dependencies": [],
   "documentation": "https://github.com/jnctech/ha-tandem-pump",
   "homekit": {},
+  "integration_type": "hub",
   "iot_class": "cloud_polling",
+  "loggers": ["httpx"],
   "issue_tracker": "https://github.com/jnctech/ha-tandem-pump/issues",
-  "requirements": ["aiofiles>=0.8.0", "certifi>=2023.0.0", "httpx>=0.23.0"],
+  "requirements": ["aiofiles==24.1.0", "certifi==2024.12.14", "httpx==0.28.1"],
   "version": "1.5.0",
   "zeroconf": []
 }

--- a/custom_components/carelink/strings.json
+++ b/custom_components/carelink/strings.json
@@ -44,6 +44,24 @@
           "nightscout_url": "Nightscout URL",
           "nightscout_api": "Nightscout API secret"
         }
+      },
+      "reauth_confirm": {
+        "title": "Re-authenticate",
+        "description": "Your credentials have expired or are invalid. Please re-enter them to continue.",
+        "data": {
+          "tandem_email": "Email address",
+          "tandem_password": "Password",
+          "tandem_region": "Region",
+          "scan_interval": "Scan interval (seconds)",
+          "cl_token": "Access token",
+          "cl_refresh_token": "Refresh token",
+          "cl_client_id": "Client ID",
+          "cl_client_secret": "Client secret",
+          "cl_mag_identifier": "MAG identifier",
+          "patientId": "Patient ID",
+          "nightscout_url": "Nightscout URL",
+          "nightscout_api": "Nightscout API secret"
+        }
       }
     },
     "error": {
@@ -53,6 +71,7 @@
     },
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
+      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
       "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]"
     }
   }

--- a/custom_components/carelink/translations/en.json
+++ b/custom_components/carelink/translations/en.json
@@ -2,6 +2,7 @@
     "config": {
         "abort": {
             "already_configured": "Device is already configured",
+            "reauth_successful": "Re-authentication was successful.",
             "reconfigure_successful": "The integration has been reconfigured successfully."
         },
         "error": {
@@ -49,6 +50,24 @@
                 "description": "Update your Nightscout connection or scan interval.",
                 "data": {
                     "scan_interval": "Scan Interval in seconds",
+                    "nightscout_url": "Nightscout URL (Optional)",
+                    "nightscout_api": "Nightscout API Secret (Optional)"
+                }
+            },
+            "reauth_confirm": {
+                "title": "Re-authenticate",
+                "description": "Your credentials have expired or are invalid. Please re-enter them to continue.",
+                "data": {
+                    "tandem_email": "Email Address",
+                    "tandem_password": "Password",
+                    "tandem_region": "Region",
+                    "scan_interval": "Scan Interval in seconds",
+                    "cl_token": "Access Token",
+                    "cl_refresh_token": "Refresh Token",
+                    "cl_client_id": "Client ID",
+                    "cl_client_secret": "Client Secret",
+                    "cl_mag_identifier": "Mag Identifier",
+                    "patientId": "Patient ID",
                     "nightscout_url": "Nightscout URL (Optional)",
                     "nightscout_api": "Nightscout API Secret (Optional)"
                 }

--- a/docs/CHANGE-REGISTER.md
+++ b/docs/CHANGE-REGISTER.md
@@ -4,6 +4,39 @@ Significant changes to this repository, listed in reverse chronological order.
 
 ---
 
+## CR-260316-iss-012-hacs-compliance — HACS Compliance Fixes (ISS-012)
+**Date:** 2026-03-16
+**Branch:** `feature/iss-012-hacs-compliance`
+**PR:** TBD
+**Status:** In Review
+
+### What Changed
+| Area | Change |
+|------|--------|
+| config_flow.py | Added `async_set_unique_id` + `_abort_if_unique_id_configured` for both Tandem and Carelink flows — prevents duplicate config entries (F-1) |
+| config_flow.py | Added `async_step_reauth` + `async_step_reauth_confirm` — reauth flow triggered by `ConfigEntryAuthFailed` (F-7) |
+| __init__.py | `TandemAuthError` in coordinator now raises `ConfigEntryAuthFailed` instead of `UpdateFailed` — triggers automatic reauth (F-9) |
+| __init__.py | Client construction wrapped in try/except → `ConfigEntryNotReady` for both Carelink and Tandem setup paths (F-8) |
+| __init__.py | `_migrate_legacy_logindata` called via `await hass.async_add_executor_job()` — no longer blocks event loop (A-6) |
+| manifest.json | Requirements pinned: `aiofiles==24.1.0`, `certifi==2024.12.14`, `httpx==0.28.1` (H-4) |
+| manifest.json | Added `integration_type: hub` (H-11) and `loggers: ["httpx"]` (H-9) |
+| strings.json, translations/en.json | Added `reauth_confirm` step strings and `reauth_successful` abort reason |
+| tests/test_config_flow.py | 9 new tests: unique ID (4), reauth flow (5) |
+| tests/test_coordinator_error_paths.py | Updated auth error test: `ConfigEntryNotReady` → `ConfigEntryAuthFailed` |
+
+### Why
+HACS default repository submission (PR #6316) requires compliance with HA integration best practices. The HACS baseline review (2026-03-16) identified 6 HIGH, 2 MEDIUM, and 2 LOW findings. This CR resolves 5 HIGH, 2 MEDIUM, and 1 LOW — with A-4a deferred as accepted risk (major refactor, clients already lifecycle-managed).
+
+### Quality Gate Results (at branch)
+| Metric | Value | Gate |
+|--------|-------|------|
+| Tests | TBD (CI) | ⏳ |
+| Ruff format | Clean | ✅ |
+| Ruff lint | Clean | ✅ |
+| Bandit | Clean | ✅ |
+
+---
+
 ## CR-016 — OpenSSF Security Baseline (Phase 7)
 **Date:** 2026-03-14
 **Branch:** `feature/openssf-security-baseline`

--- a/docs/CHANGE-REGISTER.md
+++ b/docs/CHANGE-REGISTER.md
@@ -20,8 +20,11 @@ Significant changes to this repository, listed in reverse chronological order.
 | __init__.py | `_migrate_legacy_logindata` called via `await hass.async_add_executor_job()` — no longer blocks event loop (A-6) |
 | manifest.json | Requirements pinned: `aiofiles==24.1.0`, `certifi==2024.12.14`, `httpx==0.28.1` (H-4) |
 | manifest.json | Added `integration_type: hub` (H-11) and `loggers: ["httpx"]` (H-9) |
+| __init__.py | Carelink coordinator: split login from data fetch, `login()=False` raises `ConfigEntryAuthFailed` (AUTH-01) |
+| helpers.py | Entity `unique_id` includes `entry_id` — prevents collisions in multi-entry setups (ENT-01) |
 | strings.json, translations/en.json | Added `reauth_confirm` step strings and `reauth_successful` abort reason |
 | tests/test_config_flow.py | 9 new tests: unique ID (4), reauth flow (5) |
+| tests/test_carelink_coordinator.py | Added Carelink login-returns-False test; updated login exception test |
 | tests/test_coordinator_error_paths.py | Updated auth error test: `ConfigEntryNotReady` → `ConfigEntryAuthFailed` |
 
 ### Why

--- a/docs/ISSUES.md
+++ b/docs/ISSUES.md
@@ -7,7 +7,7 @@ For quick cross-project tasks, see `~/Code/TODO.md`.
 
 ## Current Priorities
 
-1. **ISS-011 Phase 7** — OpenSSF Security Baseline + Dependabot (before HACS submission)
+1. **ISS-012** — HACS review findings (in progress — feature/iss-012-hacs-compliance)
 2. **ISS-010** — ADRs + templates done; tooling + ADR-007/008 remaining
 3. **ISS-005** — tandem_api.py coverage gap
 4. Remaining baseline findings (D-1, L-5, S-4)
@@ -15,6 +15,32 @@ For quick cross-project tasks, see `~/Code/TODO.md`.
 ---
 
 ## Active
+
+### ISS-012 — HACS Review Findings
+**Type:** Quality / HACS Compliance
+**Priority:** High
+**Created:** 2026-03-16
+**Status:** 🟢 Active — PR in progress
+**Source:** `docs/reviews/review-hacs-2026-03-16.md`
+
+**HIGH findings resolved:**
+- [x] F-1: `async_set_unique_id` + `_abort_if_unique_id_configured` in config flow
+- [x] F-9: Auth errors raise `ConfigEntryAuthFailed` (triggers reauth)
+- [x] F-8: Pre-coordinator setup failures wrapped in `ConfigEntryNotReady`
+- [x] A-6: `_migrate_legacy_logindata` sync I/O wrapped in `async_add_executor_job`
+- [x] H-4: Requirements pinned to exact `==` versions
+
+**Deferred (accepted risk):**
+- A-4a: Own httpx.AsyncClient — major refactor, clients lifecycle-managed. Not blocking for HACS.
+
+**MEDIUM resolved:**
+- [x] H-11: `integration_type: hub` added to manifest
+- [x] F-7: Reauth flow (`async_step_reauth` + `async_step_reauth_confirm`) implemented
+
+**LOW resolved:**
+- [x] H-9: `loggers` list added for httpx
+
+**Reference:** HACS submission PR: https://github.com/hacs/default/pull/6316
 
 ### ISS-010 — Architecture Decision Records & Documentation Gaps
 **Type:** Documentation / Engineering Practice

--- a/docs/reviews/review-findings.md
+++ b/docs/reviews/review-findings.md
@@ -30,8 +30,9 @@ Updated per review. Read this file first in every PR review session (~30 lines).
 | HACS-F8 | High | FIXED | feature/iss-012-hacs-compliance | Pre-coordinator setup failures wrapped in `ConfigEntryNotReady` |
 | HACS-F9 | High | FIXED | feature/iss-012-hacs-compliance | `TandemAuthError` raises `ConfigEntryAuthFailed` (triggers reauth) |
 | HACS-E8 | Low | OPEN | — | Carelink sensors missing `suggested_display_precision` |
+| HACS-AUTH1 | Critical | FIXED | feature/iss-012-hacs-compliance | Carelink login+fetch combined — auth failures now routed to reauth via `ConfigEntryAuthFailed` |
+| HACS-ENT1 | Medium | FIXED | feature/iss-012-hacs-compliance | Entity `unique_id` lacked `entry_id` — multi-entry collisions. Added `coordinator.entry_id` |
 | SFH-1 | High | OPEN | — | Therapy parse failure leaves coordinator data dict in partial state |
-| SFH-2 | High | OPEN | — | Carelink login+fetch combined — auth failures not routed to reauth |
 | SFH-3 | High | OPEN | — | import_history service silently returns on failure, no user feedback |
 | SFH-4 | Medium | OPEN | — | capture_diagnostics service silently returns on failure |
 | B-2 | Low | OPEN | — | carb_ratio 1000x multiplier from tconnectsync spec — cannot validate without real capture |

--- a/docs/reviews/review-findings.md
+++ b/docs/reviews/review-findings.md
@@ -20,6 +20,20 @@ Updated per review. Read this file first in every PR review session (~30 lines).
 | R-10 | Medium | FIXED | feature/estimated-insulin-remaining-phase6 | Negative basal time interval not clamped — could inflate remaining. Added max(0.0, ...) floor |
 | R-11 | Critical | FIXED | feature/estimated-insulin-remaining-phase6 | Partial state mutation before exception corrupts accumulator permanently — refactored to compute-then-commit pattern with local variables |
 | R-12 | Medium | FIXED | feature/estimated-insulin-remaining-phase6 | _last_delivery_seq not advanced for zero-delivery events — causes repeated processing. Now always advances |
+| HACS-H4 | High | FIXED | feature/iss-012-hacs-compliance | manifest.json requirements pinned to exact `==` versions |
+| HACS-H9 | Low | FIXED | feature/iss-012-hacs-compliance | manifest.json `loggers` list added for httpx |
+| HACS-H11 | Medium | FIXED | feature/iss-012-hacs-compliance | manifest.json `integration_type: hub` added |
+| HACS-A4a | High | DEFERRED | — | Own httpx.AsyncClient — major refactor, clients lifecycle-managed |
+| HACS-A6 | High | FIXED | feature/iss-012-hacs-compliance | `_migrate_legacy_logindata` wrapped in `async_add_executor_job` |
+| HACS-F1 | High | FIXED | feature/iss-012-hacs-compliance | `async_set_unique_id` + `_abort_if_unique_id_configured` in config flow |
+| HACS-F7 | Medium | FIXED | feature/iss-012-hacs-compliance | `async_step_reauth` + `async_step_reauth_confirm` implemented |
+| HACS-F8 | High | FIXED | feature/iss-012-hacs-compliance | Pre-coordinator setup failures wrapped in `ConfigEntryNotReady` |
+| HACS-F9 | High | FIXED | feature/iss-012-hacs-compliance | `TandemAuthError` raises `ConfigEntryAuthFailed` (triggers reauth) |
+| HACS-E8 | Low | OPEN | — | Carelink sensors missing `suggested_display_precision` |
+| SFH-1 | High | OPEN | — | Therapy parse failure leaves coordinator data dict in partial state |
+| SFH-2 | High | OPEN | — | Carelink login+fetch combined — auth failures not routed to reauth |
+| SFH-3 | High | OPEN | — | import_history service silently returns on failure, no user feedback |
+| SFH-4 | Medium | OPEN | — | capture_diagnostics service silently returns on failure |
 | B-2 | Low | OPEN | — | carb_ratio 1000x multiplier from tconnectsync spec — cannot validate without real capture |
 | D-1 | Medium | OPEN | — | No binary event fixture |
 | C-1 | High | FIXED | feature/cgm-g7-libre2-phase3 | Magic event IDs in coordinator — replaced ALL with EVT_* constants from tandem_api |

--- a/tests/test_carelink_coordinator.py
+++ b/tests/test_carelink_coordinator.py
@@ -18,7 +18,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.carelink.const import (
@@ -290,19 +290,34 @@ class TestCarelinkCoordinatorFullCycle:
         coordinator, _ = await _make_coordinator(hass, recent_data={})
         assert coordinator.data is not None
 
-    async def test_login_failure_raises_config_entry_not_ready(self, hass: HomeAssistant):
+    async def test_login_exception_raises_config_entry_not_ready(self, hass: HomeAssistant):
         """Login exception → UpdateFailed → ConfigEntryNotReady."""
         from custom_components.carelink import CarelinkCoordinator
 
         entry = _make_entry(hass)
         client = _make_client()
-        client.login = AsyncMock(side_effect=Exception("auth failed"))
+        client.login = AsyncMock(side_effect=Exception("network error"))
         hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {
             CLIENT: client,
             PLATFORM_TYPE: PLATFORM_CARELINK,
         }
         coordinator = CarelinkCoordinator(hass, entry, update_interval=timedelta(seconds=60))
         with pytest.raises(ConfigEntryNotReady):
+            await coordinator.async_config_entry_first_refresh()
+
+    async def test_login_returns_false_raises_config_entry_auth_failed(self, hass: HomeAssistant):
+        """Login returning False → ConfigEntryAuthFailed (triggers reauth)."""
+        from custom_components.carelink import CarelinkCoordinator
+
+        entry = _make_entry(hass)
+        client = _make_client()
+        client.login = AsyncMock(return_value=False)
+        hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {
+            CLIENT: client,
+            PLATFORM_TYPE: PLATFORM_CARELINK,
+        }
+        coordinator = CarelinkCoordinator(hass, entry, update_interval=timedelta(seconds=60))
+        with pytest.raises(ConfigEntryAuthFailed):
             await coordinator.async_config_entry_first_refresh()
 
     async def test_averagesg_none_sets_unavailable(self, hass: HomeAssistant):

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -668,3 +668,200 @@ class TestReconfigureFlow:
             )
         assert result["type"] == "abort"
         assert result["reason"] == "reconfigure_successful"
+
+
+class TestUniqueId:
+    """Tests for unique ID deduplication (F-1)."""
+
+    async def test_tandem_sets_unique_id(self, hass: HomeAssistant):
+        """Tandem flow sets unique ID from email + region."""
+        result = await hass.config_entries.flow.async_init(DOMAIN, context={"source": "user"})
+        result = await hass.config_entries.flow.async_configure(result["flow_id"], {PLATFORM_TYPE: PLATFORM_TANDEM})
+        with (
+            patch(
+                "custom_components.carelink.config_flow.validate_tandem_input",
+                return_value={"title": "Tandem t:slim (EU)"},
+            ),
+            patch("custom_components.carelink.async_setup_entry", return_value=True),
+        ):
+            result = await hass.config_entries.flow.async_configure(
+                result["flow_id"],
+                {
+                    "tandem_email": "User@Example.com",
+                    "tandem_password": "x",
+                    "tandem_region": "EU",
+                    "scan_interval": 300,
+                },
+            )
+            await hass.async_block_till_done()
+        assert result["type"] == "create_entry"
+        # Verify the entry got a unique_id
+        entry = hass.config_entries.async_entries(DOMAIN)[0]
+        assert entry.unique_id == "tandem_user@example.com_EU"
+
+    async def test_tandem_duplicate_aborts(self, hass: HomeAssistant):
+        """Second Tandem entry with same email + region aborts."""
+        existing = MockConfigEntry(
+            domain=DOMAIN,
+            unique_id="tandem_a@b.com_EU",
+            data={
+                PLATFORM_TYPE: PLATFORM_TANDEM,
+                "tandem_email": "a@b.com",
+                "tandem_password": "x",
+                "tandem_region": "EU",
+                "scan_interval": 300,
+            },
+        )
+        existing.add_to_hass(hass)
+
+        result = await hass.config_entries.flow.async_init(DOMAIN, context={"source": "user"})
+        result = await hass.config_entries.flow.async_configure(result["flow_id"], {PLATFORM_TYPE: PLATFORM_TANDEM})
+        with patch(
+            "custom_components.carelink.config_flow.validate_tandem_input",
+            return_value={"title": "Tandem t:slim (EU)"},
+        ):
+            result = await hass.config_entries.flow.async_configure(
+                result["flow_id"],
+                {"tandem_email": "a@b.com", "tandem_password": "y", "tandem_region": "EU", "scan_interval": 300},
+            )
+        assert result["type"] == "abort"
+        assert result["reason"] == "already_configured"
+
+    async def test_carelink_sets_unique_id_with_patient(self, hass: HomeAssistant):
+        """Carelink flow sets unique ID from patient ID."""
+        result = await hass.config_entries.flow.async_init(DOMAIN, context={"source": "user"})
+        result = await hass.config_entries.flow.async_configure(result["flow_id"], {PLATFORM_TYPE: PLATFORM_CARELINK})
+        with (
+            patch(
+                "custom_components.carelink.config_flow.validate_carelink_input",
+                return_value={"title": "Carelink"},
+            ),
+            patch("custom_components.carelink.async_setup_entry", return_value=True),
+        ):
+            result = await hass.config_entries.flow.async_configure(
+                result["flow_id"],
+                {"patientId": "patient123", "scan_interval": 60},
+            )
+            await hass.async_block_till_done()
+        assert result["type"] == "create_entry"
+        entry = hass.config_entries.async_entries(DOMAIN)[0]
+        assert entry.unique_id == "carelink_patient123"
+
+    async def test_carelink_no_patient_id_no_unique_id(self, hass: HomeAssistant):
+        """Carelink flow without patient ID creates entry without unique ID."""
+        result = await hass.config_entries.flow.async_init(DOMAIN, context={"source": "user"})
+        result = await hass.config_entries.flow.async_configure(result["flow_id"], {PLATFORM_TYPE: PLATFORM_CARELINK})
+        with (
+            patch(
+                "custom_components.carelink.config_flow.validate_carelink_input",
+                return_value={"title": "Carelink"},
+            ),
+            patch("custom_components.carelink.async_setup_entry", return_value=True),
+        ):
+            result = await hass.config_entries.flow.async_configure(
+                result["flow_id"],
+                {"scan_interval": 60},
+            )
+            await hass.async_block_till_done()
+        assert result["type"] == "create_entry"
+        entry = hass.config_entries.async_entries(DOMAIN)[0]
+        assert entry.unique_id is None
+
+
+class TestReauthFlow:
+    """Tests for reauth flow (F-7/F-9)."""
+
+    async def test_reauth_tandem_shows_form(self, hass: HomeAssistant):
+        """Reauth for Tandem entry shows the reauth_confirm form."""
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            data={
+                PLATFORM_TYPE: PLATFORM_TANDEM,
+                "tandem_email": "a@b.com",
+                "tandem_password": "old",
+                "tandem_region": "EU",
+                "scan_interval": 300,
+            },
+        )
+        entry.add_to_hass(hass)
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": "reauth", "entry_id": entry.entry_id}, data=entry.data
+        )
+        assert result["type"] == "form"
+        assert result["step_id"] == "reauth_confirm"
+
+    async def test_reauth_tandem_success(self, hass: HomeAssistant):
+        """Successful Tandem reauth updates credentials and aborts."""
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            data={
+                PLATFORM_TYPE: PLATFORM_TANDEM,
+                "tandem_email": "a@b.com",
+                "tandem_password": "old",
+                "tandem_region": "EU",
+                "scan_interval": 300,
+            },
+        )
+        entry.add_to_hass(hass)
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": "reauth", "entry_id": entry.entry_id}, data=entry.data
+        )
+        with (
+            patch(
+                "custom_components.carelink.config_flow.validate_tandem_input",
+                return_value={"title": "Tandem t:slim (EU)"},
+            ),
+            patch("custom_components.carelink.async_setup_entry", return_value=True),
+        ):
+            result = await hass.config_entries.flow.async_configure(
+                result["flow_id"],
+                {"tandem_email": "a@b.com", "tandem_password": "new", "tandem_region": "EU", "scan_interval": 300},
+            )
+            await hass.async_block_till_done()
+        assert result["type"] == "abort"
+        assert result["reason"] == "reauth_successful"
+        assert entry.data["tandem_password"] == "new"
+
+    async def test_reauth_tandem_invalid_auth(self, hass: HomeAssistant):
+        """Invalid credentials during reauth show error."""
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            data={
+                PLATFORM_TYPE: PLATFORM_TANDEM,
+                "tandem_email": "a@b.com",
+                "tandem_password": "old",
+                "tandem_region": "EU",
+                "scan_interval": 300,
+            },
+        )
+        entry.add_to_hass(hass)
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": "reauth", "entry_id": entry.entry_id}, data=entry.data
+        )
+        with patch(
+            "custom_components.carelink.config_flow.validate_tandem_input",
+            side_effect=InvalidAuth,
+        ):
+            result = await hass.config_entries.flow.async_configure(
+                result["flow_id"],
+                {"tandem_email": "a@b.com", "tandem_password": "wrong", "tandem_region": "EU", "scan_interval": 300},
+            )
+        assert result["errors"]["base"] == "invalid_auth"
+
+    async def test_reauth_carelink_shows_form(self, hass: HomeAssistant):
+        """Reauth for Carelink entry shows the reauth_confirm form."""
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            data={
+                PLATFORM_TYPE: PLATFORM_CARELINK,
+                "cl_token": "t",
+                "cl_refresh_token": "r",
+                "scan_interval": 60,
+            },
+        )
+        entry.add_to_hass(hass)
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": "reauth", "entry_id": entry.entry_id}, data=entry.data
+        )
+        assert result["type"] == "form"
+        assert result["step_id"] == "reauth_confirm"

--- a/tests/test_coordinator_error_paths.py
+++ b/tests/test_coordinator_error_paths.py
@@ -17,7 +17,7 @@ from zoneinfo import ZoneInfo
 
 import pytest
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 from unittest.mock import AsyncMock
 
@@ -96,10 +96,10 @@ async def _make_coordinator(hass: HomeAssistant):
 
 
 class TestUpdateDataLoginErrors:
-    """Login failures raise ConfigEntryNotReady (lines 869–873)."""
+    """Login failures raise appropriate exceptions."""
 
     async def test_tandemautherror_during_login(self, hass: HomeAssistant):
-        """TandemAuthError from login → UpdateFailed → ConfigEntryNotReady."""
+        """TandemAuthError from login → ConfigEntryAuthFailed (triggers reauth)."""
         from custom_components.carelink import TandemCoordinator
         from custom_components.carelink.tandem_api import TandemAuthError
 
@@ -111,7 +111,7 @@ class TestUpdateDataLoginErrors:
             PLATFORM_TYPE: PLATFORM_TANDEM,
         }
         coordinator = TandemCoordinator(hass, entry, update_interval=timedelta(seconds=300))
-        with pytest.raises(ConfigEntryNotReady):
+        with pytest.raises(ConfigEntryAuthFailed):
             await coordinator.async_config_entry_first_refresh()
         client.get_pump_event_metadata.assert_not_called()
 

--- a/tests/test_entity_device_info.py
+++ b/tests/test_entity_device_info.py
@@ -145,7 +145,7 @@ class TestPumpEntityMixinProperties:
 
     def test_unique_id_format(self):
         obj = self._make_mixin_instance(key="last_glucose_level")
-        assert obj.unique_id == f"{DOMAIN.lower()}_last_glucose_level"
+        assert obj.unique_id == f"{DOMAIN}_{_TEST_ENTRY_ID}_last_glucose_level"
 
     def test_icon_from_sensor_description(self):
         obj = self._make_mixin_instance(icon="mdi:water")


### PR DESCRIPTION
## Summary
- HACS compliance fixes (ISS-012): unique ID, reauth flow, async safety, manifest hardening, entity identity
- ADR governance: ADR-007, ADR-012 accepted; ADR-008–011 stubs
- Version bump: 1.5.0 → 1.6.0

## CI Validation
This release PR gates on all required checks before merge to master:
- [ ] Tests pass
- [ ] Ruff format clean
- [ ] Bandit clean
- [ ] SonarCloud pass
- [ ] Gitleaks clean
- [ ] Actionlint clean

## Test Plan
- [x] HA deployment tested — entity cleanup done, history maintained
- [ ] All CI checks green
- [ ] Merge to master and tag v1.6.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)