### PR TITLE
fix(ci): restrict GITHUB_TOKEN permissions (OpenSSF)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,16 +1,17 @@
 name: Release
 
-permissions:
-  contents: write
-
 on:
   release:
     types: [published]
+
+permissions: {}
 
 jobs:
   release:
     name: Build and Upload Release Asset
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
     branches: [develop, master]
 
+permissions: {}
+
 jobs:
   sonarcloud:
     name: SonarCloud Analysis
@@ -13,7 +15,6 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
-      checks: write
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -6,6 +6,8 @@ on:
   schedule:
     - cron: "0 0 * * *"
 
+permissions: {}
+
 jobs:
   validate:
     runs-on: "ubuntu-latest"


### PR DESCRIPTION
## Summary
- Add top-level `permissions: {}` to validate.yml and sonarcloud.yml
- Drop unused `checks: write` from sonarcloud.yml (SonarCloud uses SONAR_TOKEN, not GitHub checks API)
- Move `contents: write` from top-level to job-level in release.yml (principle of least privilege)

Resolves 4 OpenSSF Scorecard Token-Permissions alerts (HIGH severity).

## Test Plan
- [ ] CI passes (workflow syntax valid)
- [ ] SonarCloud still reports results (no permission regression)
- [ ] Scorecard re-run after merge to master shows Token-Permissions alerts resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)