### PR TITLE
docs: commit agent governance + context system, add drift CI

### DIFF
--- a/.github/workflows/CLAUDE.md
+++ b/.github/workflows/CLAUDE.md
@@ -1,0 +1,20 @@
+# Path-scoped rules — `.github/workflows/`
+
+Loaded when editing CI/CD. Inherits root `CLAUDE.md`. These are OpenSSF/HACS hard requirements — Scorecard regresses if broken.
+
+## Workflows (9)
+
+`ci.yml` (pytest/ruff/bandit), `validate.yml` (hassfest + HACS), `sonarcloud.yml`, `scorecard.yml` (OpenSSF), `dependency-review.yml`, `release.yml`, `conflicts.yml`, `lock.yml`, `stale.yml`.
+
+## Hard rules
+
+- **SHA-pin every action.** Use the full commit SHA, not a tag (`uses: actions/checkout@<sha>  # v4.x`). Dependabot (`github-actions` ecosystem, targets `develop`) keeps SHAs current. Tag refs are mutable → supply-chain risk → Scorecard Pinned-Dependencies failure.
+- **Top-level `permissions: {}` on every workflow**, then grant the minimum at job level (e.g. `contents: read`, `contents: write` only on the release job). Don't add `checks: write` unless a step provably needs it (it was dropped from sonarcloud.yml deliberately).
+- **New workflow → SHA-pinned + `permissions: {}` + add to this list.** This is a root STOP-and-ASK trigger.
+- **`release.yml`**: `contents: write` lives at job level, not top level.
+- Adding a GitHub Action dependency = new supply-chain surface; confirm before introducing.
+
+## Gotchas
+
+- Branch protection on `master`/`develop` requires the CI checks as the gate (PR-review requirement was removed — solo maintainer). Don't merge by bypassing checks.
+- `gitea` remote runs an inner-loop CI mirror; GitHub Actions are the source of truth.

--- a/.github/workflows/context-drift.yml
+++ b/.github/workflows/context-drift.yml
@@ -1,0 +1,129 @@
+name: Context Drift Check
+
+# Detects structural degradation in CLAUDE.md (root + path-scoped modules).
+# Adapted from the Claude Code Ultimate Guide ci-drift-check.yml.
+# Warrant: ISS-260523-ci-drift-check. Self-contained (gh CLI, no extra actions).
+#
+# Checks: root CLAUDE.md size vs threshold, broken @import references,
+# freshness (days since last commit). Opens/updates an issue on failure.
+
+on:
+  schedule:
+    - cron: '0 9 * * 1'   # Mondays 09:00 UTC
+  workflow_dispatch: {}
+  push:
+    paths:
+      - 'CLAUDE.md'
+      - 'custom_components/carelink/CLAUDE.md'
+      - 'tests/CLAUDE.md'
+      - '.github/workflows/CLAUDE.md'
+
+permissions: {}
+
+env:
+  CLAUDE_MD_MAX_LINES: '200'
+  CLAUDE_MD_WARN_LINES: '160'
+
+jobs:
+  drift-check:
+    name: Check CLAUDE.md for drift
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          fetch-depth: 0
+
+      - name: Check size, imports, freshness
+        id: check
+        run: |
+          set -euo pipefail
+          FILE="CLAUDE.md"
+          PROBLEMS=0
+          REPORT=""
+
+          if [ ! -f "$FILE" ]; then
+            echo "::error::CLAUDE.md not found at repo root"
+            echo "problems=1" >> "$GITHUB_OUTPUT"
+            echo "report=Root CLAUDE.md is missing." >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # --- size ---
+          LINES=$(wc -l < "$FILE" | tr -d ' ')
+          if [ "$LINES" -gt "$CLAUDE_MD_MAX_LINES" ]; then
+            echo "::error::CLAUDE.md $LINES lines (max $CLAUDE_MD_MAX_LINES) — modularize via @imports"
+            REPORT="${REPORT}- Size: ${LINES} lines (over max ${CLAUDE_MD_MAX_LINES})\n"
+            PROBLEMS=$((PROBLEMS + 1))
+          elif [ "$LINES" -gt "$CLAUDE_MD_WARN_LINES" ]; then
+            echo "::warning::CLAUDE.md $LINES lines (warn ${CLAUDE_MD_WARN_LINES})"
+            REPORT="${REPORT}- Size: ${LINES} lines (warn threshold ${CLAUDE_MD_WARN_LINES})\n"
+          fi
+
+          # --- broken @imports (root + modules) ---
+          BROKEN=0
+          for f in CLAUDE.md custom_components/carelink/CLAUDE.md tests/CLAUDE.md .github/workflows/CLAUDE.md; do
+            [ -f "$f" ] || continue
+            base=$(dirname "$f")
+            while IFS= read -r line; do
+              case "$line" in
+                @*)
+                  imp="${line#@}"
+                  # imports are repo-root-relative in this project
+                  if [ ! -f "$imp" ]; then
+                    echo "::error::Broken @import in $f: @$imp"
+                    REPORT="${REPORT}- Broken @import in ${f}: @${imp}\n"
+                    BROKEN=$((BROKEN + 1))
+                  fi
+                  ;;
+              esac
+            done < "$f"
+          done
+          PROBLEMS=$((PROBLEMS + BROKEN))
+
+          # --- freshness ---
+          LAST=$(git log -1 --format="%cd" --date=format:"%Y-%m-%d" -- "$FILE")
+          DAYS=$(( ( $(date +%s) - $(date -d "$LAST" +%s) ) / 86400 ))
+          if [ "$DAYS" -gt 90 ]; then
+            echo "::warning::CLAUDE.md last updated $DAYS days ago ($LAST)"
+            REPORT="${REPORT}- Freshness: last updated ${LAST} (${DAYS} days ago)\n"
+          fi
+
+          {
+            echo "problems=$PROBLEMS"
+            echo "lines=$LINES"
+            echo "days=$DAYS"
+            echo "last=$LAST"
+            printf 'report<<EOF\n%b\nEOF\n' "$REPORT"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Open or update issue on failure
+        if: steps.check.outputs.problems != '0'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          TITLE="Context Drift Detected — CLAUDE.md needs review"
+          BODY=$(printf 'The context drift check found **%s problem(s)** in CLAUDE.md.\n\n## Details\n- Size: %s lines\n- Last updated: %s (%s days ago)\n- Run: %s/%s/actions/runs/%s\n\n%b\n## Action\n1. Reduce size or modularize via @imports\n2. Fix broken @import references\n3. Review stale rules\n\n_Opened automatically by context-drift.yml._' \
+            "${{ steps.check.outputs.problems }}" "${{ steps.check.outputs.lines }}" "${{ steps.check.outputs.last }}" "${{ steps.check.outputs.days }}" "${{ github.server_url }}" "${{ github.repository }}" "${{ github.run_id }}" "${{ steps.check.outputs.report }}")
+          # ensure labels exist (idempotent)
+          gh label create ai-context --color c5def5 --description "Agent context / CLAUDE.md" 2>/dev/null || true
+          gh label create maintenance --color fef2c0 --description "Repo maintenance" 2>/dev/null || true
+          EXISTING=$(gh issue list --search "$TITLE in:title" --state open --json number --jq '.[0].number' 2>/dev/null || echo "")
+          if [ -n "$EXISTING" ]; then
+            gh issue comment "$EXISTING" --body "$BODY"
+          else
+            gh issue create --title "$TITLE" --body "$BODY" --label ai-context --label maintenance
+          fi
+
+      - name: Final status
+        if: always()
+        run: |
+          if [ "${{ steps.check.outputs.problems }}" != "0" ]; then
+            echo "Context drift: FAILED (${{ steps.check.outputs.problems }} problems)"
+            exit 1
+          fi
+          echo "Context drift: PASSED"

--- a/.gitignore
+++ b/.gitignore
@@ -158,7 +158,9 @@ config/**
 /utils/logindata.json
 venv
 .claude
-CLAUDE.md
+
+# Raw pump diagnostics dumps (capture_diagnostics service) — never commit
+carelink_diagnostics_*.json
 
 # Test config (may contain tokens)
 test_config/**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,125 @@
+# Tandem t:slim Pump — Home Assistant Integration (ha-tandem-pump)
+
+Project memory for Claude Code. Read at every session start. Source: `~/Code/hacs/Tandem-Source/Home-Assistant-Tandem-Source-Carelink`.
+
+> This file is project-scope. Global rules live in `~/.claude/CLAUDE.md`; subsystem rules live in path-scoped modules (see §Path-Scoped Modules). Keep this file under 200 lines.
+
+## Scope Discipline — Scope Warrants (read first)
+
+Certain change classes require an **accepted `docs/ISSUES.md` entry — the "scope warrant" — *before* work begins.** The warrant is an `ISS-YYMMDD-<topic>` entry the operator has accepted. Commits acting on it reference `Resolves: ISS-YYMMDD-<topic>` in the body. **If you are about to make a triggered change and there is no accepted warrant, STOP and ask. If a change is ambiguous, treat it as triggered and ask.** Producing a polished result does not excuse skipping the warrant — order matters.
+
+**Triggered (warrant required before any edit):**
+- New top-level directory, or new `docs/` subdirectory outside the existing set (`internal/`, `decisions/`, `reviews/`).
+- Introducing a filetype or convention not previously committed.
+- **Any tooling addition:** CI config / GitHub Actions, linters, generators, pre-commit hooks, dependency manifests, `manifest.json` requirements.
+- New HA platform file, new event-type decoder without an existing fixture, manifest `domain`/`version` change (see §STOP-and-ASK for the full integration-specific list).
+- A commit message using a conventional-commit type outside `docs|feat|fix|refactor|chore|test`.
+
+**In-scope by default (no warrant):**
+- Code/test changes that resolve an already-accepted issue.
+- Updating `docs/ISSUES.md` / `docs/CHANGE-REGISTER.md` to reflect work just done or to file/accept a warrant.
+- Typo / wording fixes in committed prose; status-table updates.
+
+Standing reference for governance + the maturity roadmap: `docs/internal/governance-and-maturity.md`.
+
+## Stack
+
+- HA custom_component, domain `carelink`, fork of upstream `noiwid/HAFamilyLink` (do not change upstream refs in docs unless explicitly asked).
+- Python ≥ 3.13 in CI; HA min version per `manifest.json`.
+- Two coordinators feed a single `coordinator.data` dict:
+  - `TandemSourceClient` (`tandem_api.py`) — Tandem Source REST API, binary event payloads, 5-minute polling, staleness gate.
+  - `CarelinkClient` (`api.py`) — Medtronic Carelink fallback for legacy users.
+- Tests: pytest + `pytest-homeassistant-custom-component` (HA bootstrap fixtures). Local runner is `run-tests.cmd`; CI runs in a python 3.13 devcontainer image. Coverage target ≥ 70% per CI gate.
+- Quality gates locally and in CI: `ruff check`, `ruff format --check`, `bandit -c bandit.yaml`, `gitleaks`, SonarCloud, OpenSSF Scorecard.
+
+## Architecture decisions (the why)
+
+- **One `coordinator.data` dict, two writers.** Both coordinators populate the same dict so a single sensor entity can resolve from either source. Mutation rules below are non-negotiable as a result.
+- **Stale-data handling is currently BYPASSED in production (see ISS-260523-staleness-dead-code).** The design intent: a staleness threshold (now 6 h, was 30 min) turns glucose/insulin/basal/delta sensors `unavailable` while timestamp/serial/model/software stay available. In reality `sensor.py` `available` returns `super().available` only — `is_data_stale()` (`helpers.py`) runs but is wired to nothing except an INFO log (`__init__.py:1258`). This was a temporary "DIAGNOSTIC MODE" (PR #24, 2026-03-06) never reverted. Do not describe staleness as active until that issue is resolved.
+- **Binary payload decoders are offset-sensitive.** `tandem_api.py` decodes Tandem Source events from raw bytes; offsets came from reverse-engineering, not a public contract. They are not stable across firmware. The `CartridgeFilled` regression (v1.5.0) was a 4-byte offset miss that returned `0.0` silently for months.
+- **HACS submission constraint.** Repo is on `hacs/default` (PR #6316). HACS requires `==` exact-pinned requirements, `integration_type: hub`, reauth flow, `async_set_unique_id`, and OpenSSF Token-Permissions on workflows. Don't relax any of these without an ADR.
+- **`__init__.py` is 2972 lines (known debt).** TandemCoordinator extraction tracked in ISSUES.md as a refactor — do not add new top-level helpers there; create a new module.
+
+## Conventions (productive-altitude rules)
+
+- **Never call `setdefault()` on `coordinator.data` or any nested dict on it.** Use `.get()` then explicit assignment. Mutation via `setdefault` caused the v1.0.0 "glucose graph spikes" regression where state replay overwrote real readings with `None`.
+- **Auth errors raise `ConfigEntryAuthFailed`, not `UpdateFailed`.** Both `TandemAuthError` and `CarelinkClient.login() = False` must propagate as `ConfigEntryAuthFailed` so HA triggers the reauth flow. `UpdateFailed` silently retries forever.
+- **Entity `unique_id` must include `config_entry.entry_id`.** Multi-entry setups (Tandem + Carelink in one HA instance) collide otherwise. See `helpers.py::build_unique_id`.
+- **Sync I/O on the event loop is a bug.** Anything that opens a file (`_migrate_legacy_logindata`, fixture loaders called in setup) goes through `hass.async_add_executor_job(...)`.
+- **Pinned requirements only.** `manifest.json` requirements use `==` exact versions (H-4). Don't loosen to `~=` or `>=`.
+- **Imports add a sensor → add a fixture.** Any new event-type decoder in `tandem_api.py` ships with: (a) a hex-dump fixture under `tests/fixtures/`, (b) a test in `test_tandem_api.py` or `test_expanded_data.py`, (c) the offset table in `docs/internal/tandem-source-api-binary-events.md`. No fixture, no merge.
+- **Don't mock the HA core or the database in tests.** Use `pytest-homeassistant-custom-component`'s `hass` fixture and real `MockConfigEntry`. Mock the *network* (httpx) only. This is a hard preference — mock/prod divergence has bitten before.
+- **Sensor lists drift fast.** `const.py` is 1538 lines of sensor definitions; when adding/removing, update README + `info.md` sensor counts in the same PR (HACS docs gate).
+- **No `--no-verify`, no skipped hooks, no `--no-gpg-sign`.** Local pre-commit hooks must pass. If a hook fails, fix the cause; don't bypass it.
+
+## Path-Scoped Modules
+
+Loaded on demand when files under these paths are in scope. Source these instead of duplicating the rules here.
+
+@custom_components/carelink/CLAUDE.md
+@tests/CLAUDE.md
+@.github/workflows/CLAUDE.md
+
+## Never Execute Without Approval
+
+These actions need an explicit, in-turn user confirmation — a prior approval in the session does not carry forward.
+
+- `gh release create`, `gh release edit`, `gh release delete` — releases are user-visible and downstream HACS users pick up immediately.
+- `gh pr merge` on a PR targeting `master` or `develop` — branches are protected and CI is the gate; merge is the user's call.
+- `git push --force` / `--force-with-lease` to any branch with an open PR or to `master`/`develop`/`main`.
+- `gh pr close` / `gh issue close` on items the user didn't open this session.
+- Any write to a live HA instance (`scp` into `/config/`, `ssh ... ha core restart`, edits to `.storage/`). The HA instance at `192.168.88.43` is the user's production diabetes monitoring; deploy via HACS update flow unless the user says otherwise.
+- `gh repo edit`, `gh repo rename`, `git remote set-url` — repo identity changes break HACS users' update flow.
+- Submitting or closing a PR on `hacs/default`.
+- Bumping `manifest.json` `version` — release-coupled, owner approves.
+- Removing or renaming an existing entity's `unique_id` — breaks every user's history.
+
+## Always Require Before a PR
+
+- `pytest tests/ -v` green (188+ tests; full suite, not subset).
+- `ruff check custom_components tests` clean.
+- `ruff format --check custom_components tests` clean.
+- `bandit -c bandit.yaml -r custom_components/` clean.
+- New code paths have tests (no merge of an untested coordinator branch).
+- `docs/CHANGE-REGISTER.md` updated with a `CR-YYMMDD-<branch-slug>` entry.
+- `docs/ISSUES.md` updated for any issue resolved or progressed.
+- PR target confirmed (`develop` for features, `master` only for release branches and hotfixes).
+- Manifest version is **not** bumped in feature branches — only in dedicated `release/x.y.z` branches.
+
+## STOP-and-ASK Triggers
+
+Stop and ask the user before any of these. No silent expansion of scope.
+
+- New HA platform file (`number.py`, `switch.py`, etc.) — implies entity contract and HACS impact.
+- New event-type decoder in `tandem_api.py` without an existing hex-dump fixture.
+- New entry in `manifest.json` `requirements` — every dependency is HACS-reviewed surface.
+- Adding `recorder` / `bluetooth` / other HA system dependencies to `after_dependencies`.
+- Touching `homekit`, `zeroconf`, `dhcp` discovery blocks in `manifest.json`.
+- Changing `domain` in `manifest.json` (catastrophic for existing users — entity registry break).
+- Cherry-picking from upstream `noiwid/HAFamilyLink` — fork divergence is intentional and documented in CHANGE-REGISTER.
+- Submitting an upstream PR (default PR target is always `jnctech` fork).
+- Adding a new GitHub Actions workflow — must be SHA-pinned (OpenSSF) and have `permissions: {}` at top level.
+- Disabling, downgrading, or skipping any pre-commit hook.
+
+## Anti-Patterns
+
+- **Ad-hoc shell variants in commits.** When iterating on `pytest -k ...` or `ruff format <one file>`, every shape difference triggers a new permission prompt that lands in the global allowlist. Use `run-tests.cmd` or `pytest tests/ -v` as the canonical invocations.
+- **Inline tokens in code or settings.** All Sonar/Gitea/GitHub/Authentik/Proxmox tokens live in env vars; never literal in a `Bash(curl ... -H "Authorization: token xxx")` allow entry.
+- **Generic agent personas as roles.** Pre-built agents (code-reviewer, simplifier, silent-failure-hunter) are scoped *passes*, not job titles. Use them when you need fresh context on a single concern, not to roleplay a team.
+- **Treating handoffs as a substitute for CLAUDE.md updates.** Discoveries that affect future sessions go *here* (or in a path-scoped module), not just in the next handoff file.
+
+## Session-End Hygiene
+
+Before writing the handoff:
+
+1. Did anything we discovered today belong in this file or a path-scoped module? Propose the edit, don't bury it in the handoff.
+2. Did any pre-commit / CI gate get skipped or fail? If yes, surface in the handoff under "Outstanding".
+3. Are there new untracked files in working tree that shouldn't be? Either commit them or `.gitignore` them — don't let them age.
+
+## Reference Docs
+
+- `docs/ISSUES.md` — active work, date-based IDs (`ISS-YYMMDD-<topic>`).
+- `docs/CHANGE-REGISTER.md` — significant changes (`CR-YYMMDD-<branch-slug>`).
+- `docs/decisions/` — ADRs (architecture decisions). New ADR required for: data-format changes, entity identity changes, API contracts, migrations.
+- `docs/internal/tandem-source-api-binary-events.md` — binary event payload reference.
+- Live HA SSH key for debugging logs only: `~/.ssh/ha_debug_ed25519` → `root@192.168.88.43`.

--- a/custom_components/carelink/CLAUDE.md
+++ b/custom_components/carelink/CLAUDE.md
@@ -1,0 +1,26 @@
+# Path-scoped rules — `custom_components/carelink/`
+
+Loaded when editing integration source. Inherits root `CLAUDE.md`; these are subsystem specifics.
+
+## Module map (and what NOT to grow)
+
+- `__init__.py` (~2972 lines) — **god module, known debt.** Holds both coordinators, services, file I/O, `_parse_pump_events` (1466-2170, ~700 lines), `_import_statistics`. **Do not add new top-level helpers here.** New logic → new module (`tandem_coordinator.py` extraction is the tracked target).
+- `tandem_api.py` (~1139) — `TandemSourceClient`, binary event decoders. Offset-sensitive (see root rules).
+- `api.py` (~609) — legacy `CarelinkClient` (Medtronic). Slated for deprecation; don't invest here without asking.
+- `const.py` (~1538) — `SENSORS` (Carelink) + `TANDEM_SENSORS`. Adding/removing a sensor → update README + `info.md` counts same PR.
+- `nightscout_uploader.py` — `NightscoutUploader`, wired only when `nightscout_url`/`nightscout_api` config present (`__init__.py:372`, `:595`).
+
+## Hard rules (regressions live here)
+
+- **Never `setdefault()` on `coordinator.data` or nested dicts on it.** Use `.get()` + explicit assignment. Caused the v1.0.0 glucose-spike regression. (Note: `recent_data` input dict at `__init__.py:715` uses setdefault on the *input*, not output — order-dependent, fragile, don't copy the pattern.)
+- **Binary decoder offsets are firmware-derived, not contractual.** Any new/changed offset or length in `tandem_api.py` ships with a captured (not encoder-synthesised) fixture + a value assertion. The `CartridgeFilled` 4-byte-offset bug returned `0.0` silently for months because tests round-tripped the same offsets.
+- **Validate payload length before `struct.unpack_from`.** The `len(chunk) < EVENT_LEN` guard (`tandem_api.py:126`) is load-bearing — keep all offsets within the 16-byte payload window.
+- **Auth failures raise `ConfigEntryAuthFailed`** (not `UpdateFailed`): `TandemAuthError` and Carelink `login()=False`. Network/fetch failures raise `UpdateFailed` — do **not** return `None` and let the caller treat it as empty (see ISS-260523-carelink-error-swallow, `api.py:178-185`).
+- **`unique_id` includes `config_entry.entry_id`** (multi-entry safety) — `helpers.py`.
+- **No sync I/O on the loop.** File reads, `_migrate_legacy_logindata` → `hass.async_add_executor_job(...)`.
+- **Long-term statistics use 5-minute buckets with aggregation.** Carelink path is correct (`_import_sg_statistics`, `__init__.py:967`); the Tandem path currently rounds to the hour and overwrites (ISS-260523-stats-hourly-collapse, `__init__.py:2792`) — match the Carelink pattern when fixing.
+
+## Known active correctness issues (don't reintroduce / mind when editing)
+
+- Staleness gate is **bypassed in production** — `sensor.py` `available` ignores `is_data_stale()` (ISS-260523-staleness-dead-code). Don't describe it as active.
+- Broad `except Exception` is common; most are deliberate per-item isolation. When adding one, log at `warning`+ and make sure it can't mask a decoder/data-shape regression as "no data."

--- a/docs/CHANGE-REGISTER.md
+++ b/docs/CHANGE-REGISTER.md
@@ -4,6 +4,33 @@ Significant changes to this repository, listed in reverse chronological order.
 
 ---
 
+## CR-260523-governance-context — Agent Governance + Context System
+**Date:** 2026-05-23
+**Branch:** `feature/iss-260523-governance-context`
+**Warrant:** `ISS-260523-claude-md-context`, `ISS-260523-ci-drift-check`
+**Status:** In Review
+
+### What Changed
+| Area | Change |
+|------|--------|
+| `.gitignore` | Removed the bare `CLAUDE.md` ignore (operator-authorized) so the 4 context files commit; added `carelink_diagnostics_*.json` to ignore raw pump diagnostics dumps. |
+| `CLAUDE.md` (root) | New. Productive-altitude project rules + §"Scope Discipline — Scope Warrants" (binding STOP-and-ASK + warrant-before-triggered-work, `Resolves: ISS-…`), Never-Execute-Without-Approval, path-scoped `@imports`. 125 lines. |
+| `custom_components/carelink/CLAUDE.md`, `tests/CLAUDE.md`, `.github/workflows/CLAUDE.md` | New path-scoped modules (subsystem rules loaded on demand). |
+| `docs/internal/governance-and-maturity.md` | New. Standing reference: Ultimate Guide context-engineering rules, drift-protection mechanisms, maturity warrant queue. |
+| `docs/internal/sensors-from-ha-following-PR62.md` | New. Reference snapshot of sensors observed on the HA instance after PR #62. |
+| `.github/workflows/context-drift.yml` | New. Weekly + on-change CLAUDE.md drift check (size/broken-`@import`/freshness); opens an `ai-context,maintenance` issue on failure. SHA-pinned, `permissions: {}` top-level. |
+| `docs/ISSUES.md` | Added 3 critical audit findings (ISS-260523-staleness-dead-code / -stats-hourly-collapse / -carelink-error-swallow), 1 backlog rollup, governance warrants. |
+
+### Why
+Raise tooling maturity and prevent the two drift modes that have bitten this repo: silent permanence
+(temporary changes never reverted) and mid-session scope creep. Governance written and accepted
+*before* any further tooling/code work, per operator directive and the repo's own scope protocol.
+
+### Quality Gate
+Docs/config only; no source changes. CLAUDE.md `@import`s verified resolving; root within 200-line cap.
+
+---
+
 ## CR-260316-iss-012-hacs-compliance — HACS Compliance Fixes (ISS-012)
 **Date:** 2026-03-16
 **Branch:** `feature/iss-012-hacs-compliance`

--- a/docs/ISSUES.md
+++ b/docs/ISSUES.md
@@ -7,14 +7,139 @@ For quick cross-project tasks, see `~/Code/TODO.md`.
 
 ## Current Priorities
 
-1. **ISS-012** — HACS review findings (in progress — feature/iss-012-hacs-compliance)
-2. **ISS-010** — ADRs + templates done; tooling + ADR-007/008 remaining
-3. **ISS-005** — tandem_api.py coverage gap
-4. Remaining baseline findings (D-1, L-5, S-4)
+1. **ISS-260523-staleness-dead-code** — 🔴 staleness gate bypassed in prod since 2026-03-06 (temporary diag never reverted)
+2. **ISS-260523-stats-hourly-collapse** — 🔴 Tandem long-term statistics overwrite within the hour
+3. **ISS-260523-carelink-error-swallow** — 🔴 Carelink fetch errors returned as "no data"
+4. **ISS-012** — HACS review findings (in progress — feature/iss-012-hacs-compliance)
+5. **ISS-010** — ADRs + templates done; tooling + ADR-007/008 remaining
+6. **ISS-005** — tandem_api.py coverage gap
+7. Remaining baseline findings (D-1, L-5, S-4)
 
 ---
 
 ## Active
+
+### ISS-260523-staleness-dead-code — Staleness Gate Bypassed in Production
+**Type:** Correctness / Patient Safety
+**Priority:** High
+**Created:** 2026-05-23
+**Status:** 🔴 Active — decision needed
+**Source:** Blind code audit 2026-05-23
+
+`sensor.py` `available` returns `super().available` only — the documented "stale → unavailable" behavior is absent. `is_data_stale()` (`helpers.py`, 21 passing tests) is called once, at `__init__.py:1258`, purely for an INFO log line. So volatile Tandem sensors (glucose/insulin/basal/delta) display their last-known value indefinitely with no UI signal that data is stale.
+
+**Root cause (git archaeology):** PR #24 (`dcd370c`, 2026-03-06) introduced this as **explicitly temporary** — commit body: *"DIAGNOSTIC MODE — intended for a week-long HA run to verify whether the data exchange and staleness logic is behaving correctly."* The week-long run was never reverted and never tracked. It has been live ~2.5 months. Earlier the same day, `c349d47` relaxed the threshold 30 min → **6 hours** (30 min flipped sensors unavailable on normal Bluetooth/exercise gaps).
+
+The diagnostic-mode tests were renamed (`unavailable_when_stale` → `shows_last_value_when_stale`, asserting `available=True`), so the suite is green while the documented behavior is gone — code and docs disagree.
+
+**Decision required:**
+- **Restore:** re-wire `is_data_stale(self.coordinator.data)` into `available` for volatile Tandem sensors (keep timestamp/serial/model/software available). Un-rename the 3 tests. Confirm the v1.0.0 glucose-spike regression doesn't recur (the spike was a `coordinator.data` mutation bug, unrelated to availability, so should be safe).
+- **Retract:** if last-known-value is desired, delete `is_data_stale` + its 21 tests, and update README/`info.md`/CLAUDE.md to stop claiming staleness→unavailable.
+
+**Reference:** `dcd370c`, `c349d47`, `sensor.py:67-76`, `helpers.py:18`, `__init__.py:1258`
+
+### ISS-260523-stats-hourly-collapse — Tandem Long-Term Statistics Lose Intra-Hour Resolution
+**Type:** Correctness / Data
+**Priority:** High
+**Created:** 2026-05-23
+**Status:** 🔴 Active
+**Source:** Blind code audit 2026-05-23
+
+`__init__.py:2792` rounds every pump-event timestamp to the top of the hour (`ts.replace(minute=0, second=0, microsecond=0)`), then appends one `StatisticData` per event keyed on that `start`. `async_import_statistics` keys on `start`, so ~12 same-hour CGM readings overwrite each other — last-write-wins, no mean/min/max aggregation. The method docstring (`:2753`) claims "5-minute statistics entries." The **Carelink path is correct** — `_import_sg_statistics` (`__init__.py:967`) buckets to 5-minute boundaries.
+
+**Fix:** bucket Tandem events to 5-min boundaries and aggregate (mean/min/max) per bucket before import, mirroring `_import_sg_statistics`.
+
+**Reference:** `__init__.py:2790-2806` vs `__init__.py:960-970`
+
+### ISS-260523-carelink-error-swallow — Carelink Fetch Errors Masked as Empty Data
+**Type:** Correctness / Silent Failure
+**Priority:** High
+**Created:** 2026-05-23
+**Status:** 🔴 Active
+**Source:** Blind code audit 2026-05-23
+
+`api.py:178-185` `__get_data` catches `httpx.TimeoutException`, `httpx.RequestError`, and `ValueError/KeyError`, logs only via `printdbg` (DEBUG, invisible by default), and returns `None`. The caller chain (`get_recent_data` → `CarelinkCoordinator._async_update_data:686`) treats `None` as "no data" rather than a fetch failure, so a persistent API outage looks like the pump reported nothing instead of raising `UpdateFailed`. Defeats HA's retry/repair UX.
+
+**Fix:** distinguish "fetched empty" from "fetch failed"; propagate network errors so the coordinator raises `UpdateFailed` (or `ConfigEntryAuthFailed` for auth). Promote the log from `printdbg` to `_LOGGER.warning`.
+
+**Reference:** `api.py:178-185`, `__init__.py:686`
+
+### ISS-260523-claude-md-context — Project Context System (CLAUDE.md) + Scope-Drift Protocol
+**Type:** Scope Warrant / Tooling
+**Priority:** Medium
+**Created:** 2026-05-23
+**Status:** 🟢 Resolved — committed on `feature/iss-260523-governance-context` (CR-260523-governance-context)
+
+**Context:** Session 2026-05-23 added agent-context tooling to raise maturity (per Claude Code Ultimate Guide). Introducing committed `CLAUDE.md` modules is a "new filetype convention / tooling addition" — a scope-drift trigger under the operator's protocol. This warrant retroactively accepts the work already on disk and scopes the remainder.
+
+**Accepted (already written, unstaged):**
+- `CLAUDE.md` (root) — productive-altitude project rules, STOP-and-ASK list, Never-Execute-Without-Approval, path-scoped `@imports`. (Was the explicitly approved item.)
+- `custom_components/carelink/CLAUDE.md`, `tests/CLAUDE.md`, `.github/workflows/CLAUDE.md` — path-scoped modules (written without prior warrant; accepted here).
+
+**Applied 2026-05-23 (operator directed governance be written before other work):**
+- Ported the operator's scope-drift / STOP-and-ASK + scope-warrant protocol (canonical: `the-balcony/CLAUDE.md`) into root `CLAUDE.md` §"Scope Discipline — Scope Warrants": future sessions must file an accepted `ISS-YYMMDD-<topic>` warrant before triggered changes and reference `Resolves: ISS-…` in commits.
+- Captured the Claude Code Ultimate Guide context-engineering + drift-protection recommendations and the maturity roadmap (the 5 warrant items) in `docs/internal/governance-and-maturity.md` as the standing reference.
+
+**Reference:** `the-balcony/CLAUDE.md` §"Scope discipline — STOP and ASK triggers"; `gedcom-tree-parser/CLAUDE.md` §STOP-and-ASK + Scope warrants.
+
+### ISS-260523-ci-drift-check — CLAUDE.md Context-Drift CI Check
+**Type:** Tooling / CI (scope warrant)
+**Priority:** Medium
+**Created:** 2026-05-23
+**Status:** 🟢 Resolved — committed on `feature/iss-260523-governance-context` (CR-260523-governance-context)
+**Class:** GitHub Actions addition (triggered)
+
+Add `.github/workflows/context-drift.yml` adapted from the Claude Code Ultimate Guide's
+`ci-drift-check.yml`. Weekly + on-change (CLAUDE.md / `.claude/**`) checks: file size vs threshold,
+broken `@import` references, freshness; opens an issue labelled `ai-context,maintenance` on failure.
+Thresholds: `MAX_LINES=200`, `WARN_LINES=160`. SHA-pin all actions, `permissions: {}` top-level.
+**Ref:** governance-and-maturity.md §3.1.
+
+### ISS-260523-session-start-signals — Repo-Aware SessionStart Signal
+**Type:** Tooling / Hook (scope warrant)
+**Priority:** Low
+**Created:** 2026-05-23
+**Status:** 🟡 Accepted — blocked on config-repo warrant
+**Class:** hook change (triggered) — **the hook lives in the `config` repo**
+
+Extend `config/tools/focus-brief/hooks/session-start-deploy-gate.sh` to recognise this repo's
+`docs/CHANGE-REGISTER.md` (In-Review rows) and derive the handoff slug from the repo basename
+(currently hard-coded to `*-config-*.md`). The generic ISSUES.md count already works for this repo.
+**Cross-repo:** editing the shared hook is governed by the `config` repo's own scope protocol — must
+carry a `config` repo warrant before edit. Not actioned from this repo. The `/session-start` skill
+already reads this repo's ISSUES + CHANGE-REGISTER, so the functional gap is small.
+
+### ISS-260523-allowlist-prune — Global Allowlist Prune + Deny Rules + Token Rotation
+**Type:** Tooling / Security (scope warrant)
+**Priority:** High (security)
+**Created:** 2026-05-23
+**Status:** 🟢 Accepted — actioning (deny block) 2026-05-23; full prune deferred
+**Class:** global `~/.claude/settings.json` change
+
+`~/.claude/settings.json` has ~700 one-off allow entries (no `deny` block) and **inlined live tokens**.
+Actions: (1) add Layer-1 `deny` for secret file globs [actioning now — additive, safe]; (2) advise the
+operator which tokens are leaked for rotation [doing now]; (3) generalise ~700 allow entries → ~50 verbs
+[deferred — removing relied-upon allows degrades UX, propose as reviewed diff, not blind apply].
+**Ref:** governance-and-maturity.md §3.3.
+
+### ISS-260523-v2-domain-rename — v2.0: carelink → tandem_source + Remove Legacy Medtronic
+**Type:** Migration / Breaking (scope warrant)
+**Priority:** High
+**Created:** 2026-05-23
+**Status:** 🔵 Logged — NOT actioned (operator deferred; ADR required before work)
+**Class:** manifest `domain` change (catastrophic) + legacy removal — needs an ADR
+
+HACS default rejects PR #6316 because `domain: carelink` collides with upstream
+`yo-han/Home-Assistant-Carelink` (already in the default store; owns `custom_integrations/carelink`
+in home-assistant/brands). Fix = rename domain `carelink` → `tandem_source`, rename
+`custom_components/carelink/` → `custom_components/tandem_source/`, remove the legacy Medtronic path
+(`api.py` `CarelinkClient`, `CarelinkCoordinator`, Carelink config-flow step, `SENSORS`,
+`nightscout_uploader` if Carelink-only), submit a home-assistant/brands PR for `tandem_source`, write a
+user migration guide (remove/re-add; entity history preserved via entity_id reuse), bump 2.0.0,
+CHANGELOG breaking-change note, and an ADR for the domain-identity decision.
+**Blast-radius mapping started:** `const.py:27` `DOMAIN`; `__init__.py:25,354,376,657` (Carelink);
+`config_flow.py` dual-platform steps (`:122-137,189,261`); nightscout wired at `__init__.py:372,595`.
+**Do not start without the ADR and operator go-ahead.**
 
 ### ISS-012 — HACS Review Findings
 **Type:** Quality / HACS Compliance
@@ -147,6 +272,22 @@ Upstream review of yo-han/Home-Assistant-Carelink (17 commits since fork point `
 ---
 
 ## Backlog
+
+### ISS-260523-audit-moderates — Code/Test Audit: Moderate Findings (rollup)
+**Type:** Quality / Maintainability
+**Priority:** Medium
+**Created:** 2026-05-23
+**Status:** 🟡 Backlog
+**Source:** Blind code audit 2026-05-23
+
+Rollup of moderate findings; promote individual items as worked.
+- **Decoder tests are encoder-derived round-trips.** `test_expanded_data.py` packs events with the same offsets the decoder reads back — structurally cannot catch a wrong-offset regression (the `CartridgeFilled` bug class). Only real fixture is Carelink JSON. **Fix:** commit ≥1 sanitized real Tandem pump-events blob as a golden fixture and assert decoded values. (Decoder confirmed memory-safe: `tandem_api.py:126` length guard, in-bounds offsets, truncated/invalid-base64 paths tested.)
+- **`__init__.py` is a 2,972-line god module** — two coordinators + services + file I/O + 700-line `_parse_pump_events` (1466-2170). Extraction to `tandem_coordinator.py` already noted as debt; audit confirms real cost (parser is where the offset regression lived).
+- **`setdefault` on Carelink `recent_data`** (`__init__.py:715-721`) — on the input dict not `coordinator.data`, so doesn't trip the banned regression, but order-dependent correctness shared with the nightscout uploader.
+- **40+ broad `except Exception`** in `__init__.py` — most appropriate (per-stat isolation); a few swallow therapy-parse errors into silent "no data" (e.g. `:1217-1228`).
+- **Minor cleanup:** coordinator duplication (metadata extraction, recorder-import boilerplate); legacy cruft in `api.py` (dead `VERSION="0.4"`, `__main__` CLI block, duplicate `printdbg`); confirm `nightscout_uploader.py` coverage.
+
+---
 
 ### ISS-005 — `tandem_api.py` Coverage at 47% (below 80% file-level)
 **Type:** Quality / Testing

--- a/docs/internal/governance-and-maturity.md
+++ b/docs/internal/governance-and-maturity.md
@@ -1,0 +1,77 @@
+# Governance & Tooling Maturity — Standing Reference
+
+Created 2026-05-23. The standing reference for how this repo manages agent context, prevents
+scope/context drift, and raises tooling maturity. Recommendations are grounded in the Claude Code
+Ultimate Guide (Florian Bruniaux) and the operator's own scope-drift protocol. CLAUDE.md holds the
+*binding rules*; this doc holds the *rationale and roadmap* (per the guide's rules-vs-reference split).
+
+> Warrant: `ISS-260523-claude-md-context`. Source protocol: `the-balcony/CLAUDE.md`,
+> `gedcom-tree-parser/CLAUDE.md`. Guide: https://cc.bruniaux.com/guide/
+
+---
+
+## 1. Scope-drift protocol (governance — binding)
+
+Codified in root `CLAUDE.md` §"Scope Discipline — Scope Warrants". Summary:
+
+- Triggered change classes require an **accepted `ISS-YYMMDD-<topic>` warrant before work begins**;
+  commits reference `Resolves: ISS-…`.
+- Triggered: new top-level dir / new `docs/` subdir; new filetype or convention; **any tooling
+  addition** (CI/Actions, linters, generators, hooks, dependency manifests, `manifest.json`
+  requirements); new HA platform file; decoder without fixture; manifest `domain`/`version` change;
+  off-list commit type.
+- In-scope by default: resolving an accepted issue; updating ISSUES/CHANGE-REGISTER; typo/wording;
+  status-table updates.
+- **Ambiguous → treat as triggered and ask.** A polished result does not excuse a missing warrant.
+
+This exists because the most damaging failures here have been *silent permanence*: a change made
+"temporarily" that was never reverted (see the staleness bypass, ISS-260523-staleness-dead-code,
+live ~2.5 months) and *scope creep mid-session* (writing files without a warrant).
+
+## 2. Context-engineering rules (from the Ultimate Guide)
+
+| Rule | Why | Source |
+|---|---|---|
+| All CLAUDE.md layers combined **4–8KB**; root **< 200 lines** | Adherence drops sharply past 400 lines; ~95% ≤100 lines → ~45% at 600+ | [context-engineering](https://cc.bruniaux.com/guide/ultimate-guide/03-memory-files/) |
+| **150-instruction ceiling** — rule quality beats quantity | Beyond ~150 rules, models selectively ignore; attention diffuses | guide §2 |
+| **Productive altitude** — capture decisions the model would make differently without the rule. Cut aspirational ("write clean code") and mechanical ("2-space indent" → linter) | Vague rules pass through unchanged; mechanical rules belong in ruff/editorconfig | [Goldilocks](https://github.com/FlorianBruniaux/claude-code-ultimate-guide/blob/main/guide/core/context-engineering.md) |
+| **Path-scoping via `@imports`** — load subsystem rules only when in that subsystem | 40–50% always-on context reduction with no loss of coverage | guide §4 |
+| **Continuous Context Update** — distil mid-session discoveries into CLAUDE.md, not just handoffs | Handoffs are reasoning noise; CLAUDE.md is synthesis that persists | guide §3 |
+| **MECW ~92% of advertised window** (~150K before rot on a 200K model) | n² attention scaling is structural; a lean 128K beats a stale 1M | guide §2 |
+| **Agents = context isolation, not personas** | Use scoped passes (security, perf), not job-titled "teams" | guide §2 |
+
+How this repo applies them: root `CLAUDE.md` (~180 lines, productive-altitude) + 3 path-scoped
+modules (`custom_components/carelink/`, `tests/`, `.github/workflows/`) + this reference for depth.
+
+## 3. Drift-protection mechanisms (recommended, each needs its own warrant to build)
+
+1. **CI drift-check workflow** (`ISS-260523-ci-drift-check`) — adapt the guide's `ci-drift-check.yml`:
+   weekly + on-change checks for CLAUDE.md size, broken `@import`s, freshness; auto-opens an issue
+   labelled `ai-context,maintenance`. Thresholds: `MAX_LINES=200`, `WARN_LINES=160`. **Trigger: Actions addition.**
+   Ref: https://github.com/FlorianBruniaux/claude-code-ultimate-guide/blob/main/examples/context-engineering/ci-drift-check.yml
+2. **Repo-aware session-start signal** (`ISS-260523-session-start-signals`) — extend the `focus-brief`
+   SessionStart hook to read this repo's `docs/ISSUES.md` (Active count) and `docs/CHANGE-REGISTER.md`
+   (In-Review rows). Currently it only matches the config repo's `DEPLOYMENT-REGISTRY.md`. **Trigger: tooling/hook.**
+3. **Global allowlist prune + credential rotation** (`ISS-260523-allowlist-prune`) — `~/.claude/settings.json`
+   has ~700 one-off allow entries (should generalise to ~50 verbs), **zero `deny` rules**, and **inlined
+   live tokens** (GitHub PAT, Gitea, SonarCloud, Authentik, Proxmox). Add Layer-1 `deny`
+   (`.env*`, `**/*.pem`, `**/*.key`, `**/credentials*.json`, `**/.ssh/id_*`). **Security-sensitive — rotate
+   tokens regardless of when the prune lands.** Ref: [MCP secrets](https://cc.bruniaux.com/guide/ultimate-guide/08-mcp/).
+
+## 4. Maturity roadmap (warrant queue)
+
+Order is the operator's call. None proceed without an accepted warrant.
+
+| Warrant | Scope | Class |
+|---|---|---|
+| `ISS-260523-protocol-adoption` | ✅ done — protocol in CLAUDE.md + this doc | governance |
+| `ISS-260523-ci-drift-check` | CI drift workflow | Actions |
+| `ISS-260523-session-start-signals` | repo-aware SessionStart hook | hook |
+| `ISS-260523-allowlist-prune` | global allowlist prune + `deny` + token rotation | tooling/security |
+| `ISS-260523-v2-domain-rename` | `carelink`→`tandem_source`, remove legacy Medtronic, brands PR, migration guide, ADR — unblocks HACS PR #6316 | domain change (ADR) |
+
+## 5. Open correctness issues found alongside (audit 2026-05-23)
+
+Tracked separately in ISSUES.md; listed here so governance work doesn't lose sight of them:
+`ISS-260523-staleness-dead-code` (🔴 patient-safety, live), `ISS-260523-stats-hourly-collapse` (🔴),
+`ISS-260523-carelink-error-swallow` (🔴), `ISS-260523-audit-moderates` (🟡 rollup).

--- a/docs/internal/sensors-from-ha-following-PR62.md
+++ b/docs/internal/sensors-from-ha-following-PR62.md
@@ -1,0 +1,140 @@
+
+tandem
+Filter states
+Filter attributes
+sensor.tandem_pump_model
+Pump model
+unavailable
+restored: true
+icon: mdi:code-tags
+friendly_name: Pump model
+supported_features: 0
+sensor.tandem_pump_model_2
+Tandem Pump model
+001002717
+icon: mdi:code-tags
+friendly_name: Tandem Pump model
+sensor.tandem_pump_serial_number
+Pump serial number
+unavailable
+restored: true
+icon: mdi:identifier
+friendly_name: Pump serial number
+supported_features: 0
+sensor.tandem_pump_serial_number_2
+Tandem Pump serial number
+1280942
+icon: mdi:identifier
+friendly_name: Tandem Pump serial number
+sensor.tandem_pump_suspend_reason
+Pump suspend reason
+unavailable
+restored: true
+icon: mdi:pause-circle-outline
+friendly_name: Pump suspend reason
+supported_features: 0
+sensor.tandem_pump_suspend_reason_2
+Tandem Pump suspend reason
+unknown
+icon: mdi:pause-circle-outline
+friendly_name: Tandem Pump suspend reason
+sensor.tandem_pump_suspended
+Pump suspended
+unavailable
+restored: true
+icon: mdi:pause-circle
+friendly_name: Pump suspended
+supported_features: 0
+sensor.tandem_pump_suspended_2
+Tandem Pump suspended
+Active
+icon: mdi:pause-circle
+friendly_name: Tandem Pump suspended
+sensor.tandem_software_version
+Software version
+unavailable
+restored: true
+icon: mdi:code-tags
+friendly_name: Software version
+supported_features: 0
+sensor.tandem_software_version_2
+Tandem Software version
+Control-IQ v7.8.1
+icon: mdi:code-tags
+friendly_name: Tandem Software version
+sensor.tandem_time_above_range
+Time above range
+unavailable
+restored: true
+state_class: measurement
+icon: mdi:arrow-up-bold
+friendly_name: Time above range
+supported_features: 0
+unit_of_measurement: %
+sensor.tandem_time_above_range_2
+Tandem Time above range
+75.3
+state_class: measurement
+unit_of_measurement: %
+icon: mdi:arrow-up-bold
+friendly_name: Tandem Time above range
+sensor.tandem_time_below_range
+Time below range
+unavailable
+restored: true
+state_class: measurement
+icon: mdi:arrow-down-bold
+friendly_name: Time below range
+supported_features: 0
+unit_of_measurement: %
+sensor.tandem_time_below_range_2
+Tandem Time below range
+0.0
+state_class: measurement
+unit_of_measurement: %
+icon: mdi:arrow-down-bold
+friendly_name: Tandem Time below range
+sensor.tandem_time_in_range
+Time in range
+unavailable
+restored: true
+state_class: measurement
+friendly_name: Time in range
+supported_features: 0
+unit_of_measurement: %
+sensor.tandem_time_in_range_2
+Tandem Time in range
+24.7
+state_class: measurement
+unit_of_measurement: %
+friendly_name: Tandem Time in range
+sensor.tandem_total_daily_insulin
+Total daily insulin
+unavailable
+restored: true
+icon: mdi:needle
+friendly_name: Total daily insulin
+supported_features: 0
+unit_of_measurement: units
+sensor.tandem_total_daily_insulin_2
+Tandem Total daily insulin
+unknown
+unit_of_measurement: units
+icon: mdi:needle
+friendly_name: Tandem Total daily insulin
+update.carelink_integration_update_2
+Tandem t:slim Pump update
+off
+auto_update: false
+display_precision: 0
+installed_version: v1.5.0
+in_progress: false
+latest_version: v1.5.0
+release_summary: null
+release_url: https://github.com/jnctech/ha-tandem-pump/releases/v1.5.0
+skipped_version: null
+title: null
+update_percentage: null
+entity_picture: https://brands.home-assistant.io/_/carelink/icon.png
+friendly_name: Tandem t:slim Pump update
+supported_features: 23

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -1,0 +1,20 @@
+# Path-scoped rules — `tests/`
+
+Loaded when editing tests. Inherits root `CLAUDE.md`.
+
+## Running tests
+
+- Canonical: `pytest tests/ -v` (full suite — 645+ tests). Windows wrapper: `run-tests.cmd`. CI uses a python 3.13 devcontainer image.
+- Config: `pytest.ini` — `asyncio_mode = auto`, `testpaths = tests`, `pythonpath = tests`. Don't add `-k`/`--ignore` shortcuts to committed config.
+- **Avoid ad-hoc one-file `pytest -k ...` / `ruff format <file>` variants in commits** — each new shell shape spawns a permission prompt that accumulates in the global allowlist. Use the canonical invocations.
+
+## How to write tests here
+
+- **Use real HA fixtures, don't mock the core or the DB.** `pytest-homeassistant-custom-component` provides `hass`; use `MockConfigEntry`. Mock the **network layer (httpx) only**. Mock/prod divergence has caused real misses.
+- **Decoder tests must assert against captured payloads, not encoder round-trips.** `test_expanded_data.py` currently packs events with the same offsets it reads back — that cannot catch an offset regression. A real golden fixture is the fix (ISS-260523-audit-moderates). The one real capture is `tests/fixtures/known_good_api_response.json` (Carelink JSON) — a sanitised Tandem binary blob is still needed.
+- **Cover error paths, not just happy paths**: auth failure, malformed/short payload, stale data, partial data, network error → `UpdateFailed`.
+- **Don't rename a test to make a bypass pass.** ISS-260523-staleness-dead-code happened partly because `unavailable_when_stale` tests were renamed to `shows_last_value_when_stale` and re-asserted — the suite stayed green while documented behavior vanished. If behavior changes, change the code or file an issue; don't quietly invert the assertion.
+
+## Coverage
+
+- Project gate: ≥70% (SonarCloud measures project-wide). `tandem_api.py` is individually under-covered (~47%, ISS-005) despite being the highest-risk file — add file-level coverage when touching it.


### PR DESCRIPTION
## Summary
- **Un-ignore `CLAUDE.md`** — removes the bare `CLAUDE.md` entry from `.gitignore` (operator-authorized) so the project context system is committed and shared with the team/CI instead of living only on one machine.
- **Commit the context system** — root `CLAUDE.md` plus 3 path-scoped modules (`custom_components/carelink/`, `tests/`, `.github/workflows/`).
- **Add `docs/internal/governance-and-maturity.md`** (standing governance reference) and `docs/internal/sensors-from-ha-following-PR62.md` (sensor snapshot reference).
- **Add `.github/workflows/context-drift.yml`** — weekly + on-change check of CLAUDE.md size / broken `@import`s / freshness; opens an `ai-context,maintenance` issue on failure. SHA-pinned action, `permissions: {}` top-level, minimal job perms (OpenSSF-clean).
- **Ignore `carelink_diagnostics_*.json`** — raw pump diagnostics dumps, never to be committed.
- **Tracking** — `CR-260523-governance-context` updated; `ISS-260523-claude-md-context` and `ISS-260523-ci-drift-check` marked resolved.

Resolves `ISS-260523-claude-md-context`, `ISS-260523-ci-drift-check`.

## Post-Deploy Actions
- None. Docs/config only — no integration source changed.

## Test Plan
- [ ] CI `context-drift.yml` passes on this branch (CLAUDE.md now present on checkout — previously it would have false-alarmed "not found").
- [ ] `validate.yml` (hassfest/HACS) unaffected — no manifest or source change.
- [ ] Confirm `carelink_diagnostics_*.json` no longer appears in `git status`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
